### PR TITLE
Hotfix: default export location to LocalAppdata

### DIFF
--- a/SMB3Explorer/Utils/CsvUtils.cs
+++ b/SMB3Explorer/Utils/CsvUtils.cs
@@ -10,7 +10,7 @@ namespace SMB3Explorer.Utils;
 public static class CsvUtils
 {
     private static readonly string DefaultDirectory =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "SMB3Explorer");
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMB3Explorer");
 
     private static string GetDefaultFilePath(string fileName) => Path.Combine(DefaultDirectory, fileName);
 


### PR DESCRIPTION
Default export location to LocalAppdata instead of Desktop to avoid elevated permission exception