### PR TITLE
Purge application data menu item

### DIFF
--- a/SMB3Explorer/Services/SystemInteropWrapper/ISystemInteropWrapper.cs
+++ b/SMB3Explorer/Services/SystemInteropWrapper/ISystemInteropWrapper.cs
@@ -17,9 +17,11 @@ public interface ISystemInteropWrapper
     bool FileExists(string path);
     bool FileDelete(string path);
     ValueTask FileCreate(string path);
+    long FileGetSize(string path);
     bool DirectoryExists(string path);
     void DirectoryCreate(string path);
     string[] DirectoryGetDirectories(string path);
+    string[] DirectoryGetFiles(string path, string searchPattern);
     StreamWriter CreateStreamWriter(string path);
     ICsvWriterWrapper CreateCsvWriter();
     bool ShowOpenFileDialog(OpenFileDialog openFileDialog);

--- a/SMB3Explorer/Services/SystemInteropWrapper/SystemInteropWrapper.cs
+++ b/SMB3Explorer/Services/SystemInteropWrapper/SystemInteropWrapper.cs
@@ -51,13 +51,27 @@ public class SystemInteropWrapper : ISystemInteropWrapper
 
     public bool FileDelete(string path)
     {
-        File.Delete(path);
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return false;
+        }
+
         return true;
     }
 
     public async ValueTask FileCreate(string path)
     {
         await File.Create(path).DisposeAsync();
+    }
+
+    public long FileGetSize(string path)
+    {
+        return new FileInfo(path).Length;
     }
 
     public bool DirectoryExists(string path)
@@ -73,6 +87,11 @@ public class SystemInteropWrapper : ISystemInteropWrapper
     public string[] DirectoryGetDirectories(string path)
     {
         return Directory.GetDirectories(path);
+    }
+
+    public string[] DirectoryGetFiles(string path, string searchPattern)
+    {
+        return Directory.GetFiles(path, searchPattern);
     }
 
     public StreamWriter CreateStreamWriter(string path)

--- a/SMB3Explorer/Utils/AppData.cs
+++ b/SMB3Explorer/Utils/AppData.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OneOf;
+using SMB3Explorer.Services.SystemInteropWrapper;
+
+namespace SMB3Explorer.Utils;
+
+public static class AppData
+{
+    private static IEnumerable<string> GetApplicationDataFiles(ISystemInteropWrapper systemInteropWrapper, string ignoreFile)
+    {
+        var tempPath = Path.GetTempPath();
+        return systemInteropWrapper.DirectoryGetFiles(tempPath, "smb3_explorer_*.sqlite")
+            .Where(_ => !_.Equals(ignoreFile, StringComparison.OrdinalIgnoreCase));
+    }
+    
+    public static AppDataSummary GetApplicationDataSize(ISystemInteropWrapper systemInteropWrapper, string ignoreFile)
+    {
+        var files = GetApplicationDataFiles(systemInteropWrapper, ignoreFile).ToList();
+        return new AppDataSummary(files.Count, files.Sum(systemInteropWrapper.FileGetSize));
+    }
+    
+    public static Task<List<AppDataFailedPurgeResult>> PurgeApplicationData(ISystemInteropWrapper systemInteropWrapper, string ignoreFile)
+    {
+        var files = GetApplicationDataFiles(systemInteropWrapper, ignoreFile);
+        
+        var results = new List<AppDataFailedPurgeResult>();
+        foreach (var file in files)
+        {
+            var size = systemInteropWrapper.FileGetSize(file);
+            var ok = systemInteropWrapper.FileDelete(file);
+            
+            if (!ok) results.Add(new AppDataFailedPurgeResult(file, size));
+        }
+        
+        return Task.FromResult(results);
+    }
+}
+
+public record struct AppDataSummary(int NumberOfFiles, long TotalSize);
+
+public record struct AppDataFailedPurgeResult(string FileName, long Size);

--- a/SMB3Explorer/Utils/FormattedStringBytes.cs
+++ b/SMB3Explorer/Utils/FormattedStringBytes.cs
@@ -4,7 +4,7 @@ namespace SMB3Explorer.Utils;
 
 public static class FormattedStringBytes
 {
-    public static string BytesToString(long byteCount)
+    public static string ToFileSizeString(this long byteCount)
     {
         return byteCount switch
         {

--- a/SMB3Explorer/Utils/FormattedStringBytes.cs
+++ b/SMB3Explorer/Utils/FormattedStringBytes.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace SMB3Explorer.Utils;
+
+public static class FormattedStringBytes
+{
+    public static string BytesToString(long byteCount)
+    {
+        return byteCount switch
+        {
+            < 0 => throw new ArgumentOutOfRangeException(nameof(byteCount)),
+            < 1024 => $"{byteCount}B",
+            < 1048576 => $"{byteCount / 1024.0:0.##}KB",
+            < 1073741824 => $"{byteCount / 1048576.0:0.##}MB",
+            _ => $"{byteCount / 1073741824.0:0.##}GB"
+        };
+    }
+}

--- a/SMB3Explorer/ViewModels/MainWindowViewModel.cs
+++ b/SMB3Explorer/ViewModels/MainWindowViewModel.cs
@@ -103,8 +103,15 @@ public partial class MainWindowViewModel : ViewModelBase
     private async Task PurgeApplicationData()
     {
         var appDataSummary = AppData.GetApplicationDataSize(_systemInteropWrapper, _dataService.CurrentFilePath);
+        if (appDataSummary.NumberOfFiles == 0)
+        {
+            _systemInteropWrapper.ShowMessageBox("No application data to delete.", "No Application Data",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        
         var message = $"Are you sure you want to delete {appDataSummary.NumberOfFiles} .sqlite files " +
-                      $"totalling {FormattedStringBytes.BytesToString(appDataSummary.TotalSize)} bytes?";
+                      $"totalling {appDataSummary.TotalSize.ToFileSizeString()}?";
 
         var result = _systemInteropWrapper.ShowMessageBox(message, "Purge Application Data", MessageBoxButton.YesNo,
             MessageBoxImage.Question);
@@ -127,7 +134,7 @@ public partial class MainWindowViewModel : ViewModelBase
         foreach (var _ in failedPurgeResults)
         {
             failedMessage.AppendLine(
-                $"{Environment.NewLine}{_.FileName} ({FormattedStringBytes.BytesToString(_.Size)})");
+                $"{Environment.NewLine}{_.FileName} ({_.Size.ToFileSizeString()})");
         }
 
         _systemInteropWrapper.ShowMessageBox(failedMessage.ToString(), "Failed to delete", MessageBoxButton.OK,

--- a/SMB3Explorer/ViewModels/MainWindowViewModel.cs
+++ b/SMB3Explorer/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,11 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
+using SMB3Explorer.Services.DataService;
 using SMB3Explorer.Services.NavigationService;
 using SMB3Explorer.Services.SystemInteropWrapper;
 using SMB3Explorer.Utils;
@@ -11,14 +16,17 @@ public partial class MainWindowViewModel : ViewModelBase
 {
     public INavigationService NavigationService { get; }
 
-    private ISystemInteropWrapper _systemInteropWrapper;
+    private readonly ISystemInteropWrapper _systemInteropWrapper;
+    private readonly IDataService _dataService;
 
-    public MainWindowViewModel(INavigationService navigationService, ISystemInteropWrapper systemInteropWrapper)
+    public MainWindowViewModel(INavigationService navigationService, ISystemInteropWrapper systemInteropWrapper,
+        IDataService dataService)
     {
         NavigationService = navigationService;
         _systemInteropWrapper = systemInteropWrapper;
+        _dataService = dataService;
     }
-    
+
     public Task Initialize()
     {
         NavigationService.NavigateTo<LandingViewModel>();
@@ -26,19 +34,19 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     private static string CurrentVersion => Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "Unknown";
-    
+
     public static string CurrentVersionString => $"Version {CurrentVersion}";
 
     [RelayCommand]
     private Task OpenExportsFolder()
     {
         var defaultDirectory = CsvUtils.DefaultDirectory;
-        
+
         if (!_systemInteropWrapper.DirectoryExists(defaultDirectory))
         {
             _systemInteropWrapper.DirectoryCreate(defaultDirectory);
         }
-        
+
         SafeProcess.Start(defaultDirectory, _systemInteropWrapper);
         return Task.CompletedTask;
     }
@@ -89,5 +97,40 @@ public partial class MainWindowViewModel : ViewModelBase
         const string githubUrl = "https://github.com/tbrittain/SMB3Explorer";
         SafeProcess.Start(githubUrl, _systemInteropWrapper);
         return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task PurgeApplicationData()
+    {
+        var appDataSummary = AppData.GetApplicationDataSize(_systemInteropWrapper, _dataService.CurrentFilePath);
+        var message = $"Are you sure you want to delete {appDataSummary.NumberOfFiles} .sqlite files " +
+                      $"totalling {FormattedStringBytes.BytesToString(appDataSummary.TotalSize)} bytes?";
+
+        var result = _systemInteropWrapper.ShowMessageBox(message, "Purge Application Data", MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes) return;
+
+        Mouse.OverrideCursor = Cursors.Wait;
+        var failedPurgeResults = await AppData.PurgeApplicationData(_systemInteropWrapper,
+            _dataService.CurrentFilePath);
+        Mouse.OverrideCursor = Cursors.Arrow;
+        
+        if (failedPurgeResults.Count == 0)
+        {
+            _systemInteropWrapper.ShowMessageBox("All files deleted successfully.", "Success",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var failedMessage = new StringBuilder($"Failed to delete {failedPurgeResults.Count} files:");
+        foreach (var _ in failedPurgeResults)
+        {
+            failedMessage.AppendLine(
+                $"{Environment.NewLine}{_.FileName} ({FormattedStringBytes.BytesToString(_.Size)})");
+        }
+
+        _systemInteropWrapper.ShowMessageBox(failedMessage.ToString(), "Failed to delete", MessageBoxButton.OK,
+            MessageBoxImage.Warning);
     }
 }

--- a/SMB3Explorer/Views/MainWindow.xaml
+++ b/SMB3Explorer/Views/MainWindow.xaml
@@ -16,7 +16,7 @@
             <MenuItem Header="_File">
                 <MenuItem Header="_Open exports folder" Command="{Binding OpenExportsFolderCommand}" />
                 <MenuItem Header="_Deselect current save file" /> <!-- TODO -->
-                <MenuItem Header="_Purge application data" /> <!-- TODO -->
+                <MenuItem Header="_Purge application data" Command="{Binding PurgeApplicationDataCommand}" />
             </MenuItem>
 
             <MenuItem Header="_Help">


### PR DESCRIPTION
- Add purge application data menu item
- Removes unused `.sqlite` database snapshots cloned from the save game
  - Ignores the current one in use by the application
- Closes #40 