### PR TITLE
Improved logging app-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+/.idea/

--- a/SMB3Explorer/App.xaml.cs
+++ b/SMB3Explorer/App.xaml.cs
@@ -2,13 +2,14 @@
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
-using SMB3Explorer.Services;
+using Serilog;
 using SMB3Explorer.Services.ApplicationContext;
 using SMB3Explorer.Services.CsvWriterWrapper;
 using SMB3Explorer.Services.DataService;
 using SMB3Explorer.Services.HttpClient;
 using SMB3Explorer.Services.NavigationService;
 using SMB3Explorer.Services.SystemInteropWrapper;
+using SMB3Explorer.Utils;
 using SMB3Explorer.ViewModels;
 using SMB3Explorer.Views;
 
@@ -22,6 +23,7 @@ public partial class App
     protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+        Logger.InitializeLogger();
         Services = new ServiceCollection();
         await ConfigureServices(Services);
         ServiceProvider = Services.BuildServiceProvider();
@@ -33,6 +35,7 @@ public partial class App
 
     private static Task ConfigureServices(IServiceCollection services)
     {
+        Log.Information("Configuring services...");
         services.AddHttpClient();
         services.AddSingleton<IHttpService, HttpService>();
         services.AddSingleton<IDataService, DataService>();
@@ -54,6 +57,13 @@ public partial class App
         services.AddSingleton<Func<Type, ViewModelBase>>(serviceProvider =>
             viewModelType => (ViewModelBase) serviceProvider.GetRequiredService(viewModelType));
         
+        Log.Information("Finished configuring services");
         return Task.CompletedTask;
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        Log.CloseAndFlush();
+        base.OnExit(e);
     }
 }

--- a/SMB3Explorer/Resources/Sql/PlayoffStatsBatting.sql
+++ b/SMB3Explorer/Resources/Sql/PlayoffStatsBatting.sql
@@ -1,10 +1,19 @@
 ﻿WITH teams AS
          (SELECT ttli.GUID AS teamGUID, tt.teamName
           FROM t_team_local_ids ttli
-                   JOIN t_teams tt ON ttli.GUID = tt.GUID)
+                   JOIN t_teams tt ON ttli.GUID = tt.GUID),
+     seasons AS (
+         SELECT id AS seasonID,
+                RANK() OVER (ORDER BY id) AS seasonNum
+         FROM t_seasons
+                  JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
+                  JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
+         WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
+     )
 SELECT baseballPlayerGUID,
        tsea.completionDate,
        tsea.ID                                        AS seasonId,
+       s.seasonNum,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[firstName]
            ELSE vbpi.[firstName] END                  AS firstName,
@@ -29,6 +38,7 @@ FROM [v_baseball_player_info] vbpi
          LEFT JOIN t_playoff_stats tps ON ts.aggregatorID = tps.aggregatorID
 
          JOIN t_seasons tsea ON tps.seasonID = tsea.ID
+         JOIN seasons s ON tsea.ID = s.seasonID
          JOIN t_league_local_ids tlli ON tsp.leagueLocalID = tlli.localID
          JOIN t_leagues tl ON tlli.GUID = tl.GUID
 

--- a/SMB3Explorer/Resources/Sql/PlayoffStatsPitching.sql
+++ b/SMB3Explorer/Resources/Sql/PlayoffStatsPitching.sql
@@ -1,10 +1,19 @@
 ﻿WITH teams AS
          (SELECT ttli.GUID AS teamGUID, tt.teamName
           FROM t_team_local_ids ttli
-                   JOIN t_teams tt ON ttli.GUID = tt.GUID)
+                   JOIN t_teams tt ON ttli.GUID = tt.GUID),
+     seasons AS (
+         SELECT id AS seasonID,
+                RANK() OVER (ORDER BY id) AS seasonNum
+         FROM t_seasons
+                  JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
+                  JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
+         WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
+     )
 SELECT baseballPlayerGUID,
        tsea.completionDate,
        tsea.ID                                        AS seasonId,
+       s.seasonNum,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[firstName]
            ELSE vbpi.[firstName] END                  AS firstName,
@@ -28,6 +37,7 @@ FROM [v_baseball_player_info] vbpi
          LEFT JOIN t_playoff_stats tps ON ts.aggregatorID = tps.aggregatorID
 
          JOIN t_seasons tsea ON tps.seasonID = tsea.ID
+         JOIN seasons s ON tsea.ID = s.seasonID
          JOIN t_league_local_ids tlli ON tsp.leagueLocalID = tlli.localID
          JOIN t_leagues tl ON tlli.GUID = tl.GUID
 

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -18,6 +18,7 @@
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
       <PackageReference Include="CsvHelper" Version="30.0.1" />
       <PackageReference Include="DotNetZip" Version="1.16.0" />
+      <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -18,12 +18,14 @@
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
       <PackageReference Include="CsvHelper" Version="30.0.1" />
       <PackageReference Include="DotNetZip" Version="1.16.0" />
-      <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="OneOf" Version="3.0.243" />
+      <PackageReference Include="Serilog" Version="2.12.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
@@ -208,8 +208,7 @@ public partial class DataService
         return pitcherStatistic;
     }
 
-    private static BattingSeasonStatistic GetPositionPlayerSeasonStatistic(bool isRegularSeason,
-        SqliteDataReader reader)
+    private static BattingSeasonStatistic GetPositionPlayerSeasonStatistic(bool isRegularSeason, IDataRecord reader)
     {
         var positionPlayerStatistic = new BattingSeasonStatistic();
 

--- a/SMB3Explorer/Services/HttpClient/IHttpService.cs
+++ b/SMB3Explorer/Services/HttpClient/IHttpService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using OneOf;
 using OneOf.Types;
 using SMB3Explorer.Models.Internal;

--- a/SMB3Explorer/Services/SystemInteropWrapper/SystemIoWrapper.cs
+++ b/SMB3Explorer/Services/SystemInteropWrapper/SystemIoWrapper.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using Ionic.Zlib;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
+using Serilog;
 using SMB3Explorer.Services.CsvWriterWrapper;
 
 namespace SMB3Explorer.Services.SystemInteropWrapper;
@@ -58,7 +59,7 @@ public class SystemIoWrapper : ISystemIoWrapper
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
+            Log.Error(e, "Failed to delete file {Path}", path);
             return false;
         }
 

--- a/SMB3Explorer/Utils/CsvUtils.cs
+++ b/SMB3Explorer/Utils/CsvUtils.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using SMB3Explorer.Services.CsvWriterWrapper;
+using Serilog;
 using SMB3Explorer.Services.SystemInteropWrapper;
 
 namespace SMB3Explorer.Utils;
@@ -20,6 +19,7 @@ public static class CsvUtils
     {
         if (!systemIoWrapper.DirectoryExists(DefaultDirectory))
         {
+            Log.Debug("Creating directory {DefaultDirectory}", DefaultDirectory);
             systemIoWrapper.DirectoryCreate(DefaultDirectory);
         }
         
@@ -27,6 +27,7 @@ public static class CsvUtils
         
         if (systemIoWrapper.FileExists(filePath)) systemIoWrapper.FileDelete(filePath);
         await systemIoWrapper.FileCreate(filePath);
+        Log.Debug("Created file {FilePath}", filePath);
 
         var rowCount = 1;
         await using var writer = systemIoWrapper.CreateStreamWriter(filePath);
@@ -35,6 +36,7 @@ public static class CsvUtils
 
         await csv.WriteHeaderAsync<T>();
 
+        Log.Debug("Writing records to {FilePath}", filePath);
         var enumerator = records.GetAsyncEnumerator();
         while (await enumerator.MoveNextAsync())
         {
@@ -47,6 +49,8 @@ public static class CsvUtils
 
             rowCount++;
         }
+        
+        Log.Debug("Finished writing {RowCount} records to {FilePath}", rowCount, filePath);
 
         return (filePath, rowCount);
     }

--- a/SMB3Explorer/Utils/DefaultExceptionHandler.cs
+++ b/SMB3Explorer/Utils/DefaultExceptionHandler.cs
@@ -1,36 +1,44 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
+using Serilog;
 using SMB3Explorer.Services.SystemInteropWrapper;
 
 namespace SMB3Explorer.Utils;
 
 public static class DefaultExceptionHandler
 {
-    public const string GithubNewIssueUrl = "https://github.com/tbrittain/SMB3Explorer/issues/new";
+    public const string GithubNewBugUrl =
+        "https://github.com/tbrittain/SMB3Explorer/issues/new?labels=bug&template=bug_report.md";
 
     public static void HandleException(ISystemIoWrapper systemIoWrapper, string userFriendlyMessage,
         Exception exception)
     {
+        Log.Warning("Caught exception, attempting to handle gracefully");
         var initialMessage = $"{userFriendlyMessage} " +
-                             "A full stack trace has been copied to your clipboard. " +
-                             "Press OK to report this issue on GitHub.";
+                             "The error has been logged to a text file. " +
+                             "Press OK to open the log folder and report this issue on GitHub.";
 
+        Log.Error(exception, "Original exception");
         if (exception.InnerException is not null)
         {
+            Log.Debug("Exception has inner exception, logging");
             exception = exception.InnerException;
+            Log.Error(exception, "Inner exception");
         }
 
         var formattedMessage = $"{initialMessage}{Environment.NewLine}{exception.Message}";
 
         var openBrowser = systemIoWrapper.ShowMessageBox(formattedMessage,
             "Error", MessageBoxButton.OKCancel, MessageBoxImage.Error);
-        
-        var stackTrace = exception.StackTrace ?? "Unknown error";
-        systemIoWrapper.SetClipboardText($"{exception.Message}{stackTrace}");
 
         if (openBrowser != MessageBoxResult.OK) return;
 
-        systemIoWrapper.StartProcess(new ProcessStartInfo("cmd", $"/c start {GithubNewIssueUrl}"));
+        Log.Debug("Opening log directory and browser to report bug");
+        Logger.FlushAndRestartLogger();
+
+        SafeProcess.Start(Logger.LogDirectory, systemIoWrapper);
+        SafeProcess.Start(GithubNewBugUrl, systemIoWrapper);
     }
 }

--- a/SMB3Explorer/Utils/DefaultExceptionHandler.cs
+++ b/SMB3Explorer/Utils/DefaultExceptionHandler.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
 using System.Windows;
 using Serilog;
 using SMB3Explorer.Services.SystemInteropWrapper;

--- a/SMB3Explorer/Utils/Logger.cs
+++ b/SMB3Explorer/Utils/Logger.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using Serilog;
+
+namespace SMB3Explorer.Utils;
+
+public static class Logger
+{
+    internal static string LogDirectory { get; private set; } = string.Empty;
+    internal static string LogPath { get; private set; } = string.Empty;
+    
+    public static void InitializeLogger()
+    {
+        LogDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SMB3Explorer", "Logs");
+        LogPath = Path.Combine(LogDirectory, $"log_{DateTime.Now:yyyyMMddHHmmssfff}.txt");
+
+#if RELEASE
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .WriteTo.File(LogPath)
+            .MinimumLevel.Warning()
+            .CreateLogger();
+#else
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .WriteTo.File(LogPath)
+            .MinimumLevel.Debug()
+            .CreateLogger();
+#endif
+    }
+    
+    internal static void FlushAndRestartLogger()
+    {
+        Log.Information("Restarting logger");
+        
+        Log.CloseAndFlush();
+        InitializeLogger();
+        
+        Log.Information("Logger restarted");
+    }
+}

--- a/SMB3Explorer/Utils/Logger.cs
+++ b/SMB3Explorer/Utils/Logger.cs
@@ -19,7 +19,7 @@ public static class Logger
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()
             .WriteTo.File(LogPath)
-            .MinimumLevel.Warning()
+            .MinimumLevel.Information()
             .CreateLogger();
 #else
         Log.Logger = new LoggerConfiguration()

--- a/SMB3Explorer/Utils/SafeProcess.cs
+++ b/SMB3Explorer/Utils/SafeProcess.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+using Serilog;
 using SMB3Explorer.Services.SystemInteropWrapper;
 
 namespace SMB3Explorer.Utils;
@@ -21,6 +22,7 @@ public static class SafeProcess
         }
         catch (Win32Exception e)
         {
+            Log.Error(e, "Failed to start process {FileName}", fileName);
             DefaultExceptionHandler.HandleException(systemIoWrapper, "Failed to start process.", e);
         }
     }

--- a/SMB3Explorer/Utils/SafeProcess.cs
+++ b/SMB3Explorer/Utils/SafeProcess.cs
@@ -9,6 +9,7 @@ public static class SafeProcess
 {
     public static void Start(string fileName, ISystemIoWrapper systemIoWrapper)
     {
+        Log.Debug("Starting process {FileName}", fileName);
         var startInfo = new ProcessStartInfo
         {
             FileName = fileName,

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -268,7 +268,7 @@ public partial class HomeViewModel : ViewModelBase
         _dataService.GetFranchises()
             .ContinueWith(async task =>
             {
-                if (task.Exception != null)
+                if (task.Exception is not null)
                 {
                     DefaultExceptionHandler.HandleException(_systemIoWrapper, "Failed to get franchises.", task.Exception);
                     LoadingSpinnerVisible = Visibility.Collapsed;

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -48,6 +48,8 @@ public partial class HomeViewModel : ViewModelBase
             SetField(ref _selectedFranchise, value);
             _applicationContext.SelectedFranchise = value;
             OnPropertyChanged(nameof(FranchiseSelected));
+            
+            Log.Information("Changed current league to {League}", value?.LeagueName ?? "None");
 
             if (_selectedFranchise is null)
             {

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -49,7 +49,7 @@ public partial class HomeViewModel : ViewModelBase
             _applicationContext.SelectedFranchise = value;
             OnPropertyChanged(nameof(FranchiseSelected));
             
-            Log.Information("Changed current league to {League}", value?.LeagueName ?? "None");
+            Log.Information("Changed current league to {League} ({LeagueGuid})", value?.LeagueName ?? "None", value?.LeagueId ?? Guid.Empty);
 
             if (_selectedFranchise is null)
             {

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -117,7 +117,7 @@ public partial class HomeViewModel : ViewModelBase
 
     private async Task HandleFranchiseCareerBattingExport(bool isRegularSeason = true)
     {
-        Log.Debug("Exporting franchise career batting statistics when isRegularSeason = {IsRegularSeason}", isRegularSeason);
+        Log.Information("Exporting franchise career batting statistics when isRegularSeason = {IsRegularSeason}", isRegularSeason);
         Mouse.OverrideCursor = Cursors.Wait;
 
         var playersEnumerable = _dataService.GetFranchiseCareerBattingStatistics(isRegularSeason);
@@ -134,7 +134,7 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
 
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Finished exporting franchise career batting statistics to {FilePath}", filePath);
+        Log.Information("Finished exporting franchise career batting statistics to {FilePath}", filePath);
     }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
@@ -151,7 +151,7 @@ public partial class HomeViewModel : ViewModelBase
 
     private async Task HandleFranchiseCareerPitchingExport(bool isRegularSeason = true)
     {
-        Log.Debug("Exporting franchise career pitching statistics where isRegularSeason = {IsRegularSeason}", isRegularSeason);
+        Log.Information("Exporting franchise career pitching statistics where isRegularSeason = {IsRegularSeason}", isRegularSeason);
         Mouse.OverrideCursor = Cursors.Wait;
 
         var playersEnumerable = _dataService.GetFranchiseCareerPitchingStatistics(isRegularSeason);
@@ -168,7 +168,7 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
 
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Finished exporting franchise career pitching statistics to {FilePath}", filePath);
+        Log.Information("Finished exporting franchise career pitching statistics to {FilePath}", filePath);
     }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
@@ -185,7 +185,7 @@ public partial class HomeViewModel : ViewModelBase
     
     private async Task HandleFranchiseSeasonBattingExport(bool isRegularSeason = true)
     {
-        Log.Debug("Exporting franchise season batting statistics where isRegularSeason = {IsRegularSeason}", isRegularSeason);
+        Log.Information("Exporting franchise season batting statistics where isRegularSeason = {IsRegularSeason}", isRegularSeason);
         Mouse.OverrideCursor = Cursors.Wait;
 
         var playersEnumerable = _dataService.GetFranchiseSeasonBattingStatistics(isRegularSeason);
@@ -202,7 +202,7 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
 
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Finished exporting franchise season batting statistics to {FilePath}", filePath);
+        Log.Information("Finished exporting franchise season batting statistics to {FilePath}", filePath);
     }
     
     [RelayCommand(CanExecute = nameof(CanExport))]
@@ -219,7 +219,7 @@ public partial class HomeViewModel : ViewModelBase
     
     private async Task HandleFranchiseSeasonPitchingExport(bool isRegularSeason = true)
     {
-        Log.Debug("Exporting franchise season pitching statistics where isRegularSeason={IsRegularSeason}", isRegularSeason);
+        Log.Information("Exporting franchise season pitching statistics where isRegularSeason={IsRegularSeason}", isRegularSeason);
         Mouse.OverrideCursor = Cursors.Wait;
 
         var playersEnumerable = _dataService.GetFranchiseSeasonPitchingStatistics(isRegularSeason);
@@ -236,13 +236,13 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
 
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Finished exporting franchise season pitching statistics to {FilePath}", filePath);
+        Log.Information("Finished exporting franchise season pitching statistics to {FilePath}", filePath);
     }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
     private async Task ExportFranchiseTeamSeasonStandings()
     {
-        Log.Debug("Exporting franchise season standings...");
+        Log.Information("Exporting franchise season standings...");
         Mouse.OverrideCursor = Cursors.Wait;
 
         var teamsEnumerable = _dataService.GetFranchiseSeasonStandings();
@@ -258,13 +258,13 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
         
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Finished exporting franchise season standings to {FilePath}", filePath);
+        Log.Information("Finished exporting franchise season standings to {FilePath}", filePath);
     }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
     private async Task ExportFranchiseTeamPlayoffStandings()
     {
-        Log.Debug("Exporting franchise playoff standings...");
+        Log.Information("Exporting franchise playoff standings...");
         Mouse.OverrideCursor = Cursors.Wait;
 
         var teamsEnumerable = _dataService.GetFranchisePlayoffStandings();
@@ -280,7 +280,7 @@ public partial class HomeViewModel : ViewModelBase
         if (ok == MessageBoxResult.Yes) SafeProcess.Start(filePath, _systemIoWrapper);
         
         Mouse.OverrideCursor = Cursors.Arrow;
-        Log.Debug("Exported franchise playoff standings to {FilePath}", filePath);
+        Log.Information("Exported franchise playoff standings to {FilePath}", filePath);
     }
     
     private bool CanExport() => FranchiseSelected;
@@ -289,7 +289,7 @@ public partial class HomeViewModel : ViewModelBase
     {
         LoadingSpinnerVisible = Visibility.Visible;
 
-        Log.Debug("Getting franchises...");
+        Log.Information("Getting franchises...");
         _dataService.GetFranchises()
             .ContinueWith(async task =>
             {

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -50,6 +50,9 @@ public partial class HomeViewModel : ViewModelBase
         {
             SetField(ref _selectedFranchise, value);
             _applicationContext.SelectedFranchise = value;
+            
+            var leagueName = value?.LeagueNameSafe ?? "None";
+            Log.Information("Set selected league to {LeagueNameSafe}", leagueName);
             OnPropertyChanged(nameof(FranchiseSelected));
         }
     }

--- a/SMB3Explorer/ViewModels/LandingViewModel.cs
+++ b/SMB3Explorer/ViewModels/LandingViewModel.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
+using OneOf;
+using OneOf.Types;
+using Serilog;
 using SMB3Explorer.Services.DataService;
 using SMB3Explorer.Services.NavigationService;
 using SMB3Explorer.Services.SystemInteropWrapper;
@@ -21,6 +24,8 @@ public partial class LandingViewModel : ViewModelBase
         _navigationService = navigationService;
         _systemIoWrapper = systemIoWrapper;
         _dataService = dataService;
+        
+        Log.Information("Initializing LandingViewModel");
 
         _dataService.ConnectionChanged += DataServiceOnConnectionChanged;
     }
@@ -50,8 +55,8 @@ public partial class LandingViewModel : ViewModelBase
             return;
         }
         
-        var hasError = await EstablishDbConnection(filePath);
-        HandleDatabaseConnection(hasError);
+        var connectionResult = await EstablishDbConnection(filePath);
+        HandleDatabaseConnection(connectionResult);
     }
 
     [RelayCommand(CanExecute = nameof(CanSelectSaveFile))]
@@ -68,8 +73,8 @@ public partial class LandingViewModel : ViewModelBase
             return;
         }
 
-        var hasError = await EstablishDbConnection(filePath);
-        HandleDatabaseConnection(hasError);
+        var connectionResult = await EstablishDbConnection(filePath);
+        HandleDatabaseConnection(connectionResult);
     }
 
     [RelayCommand(CanExecute = nameof(CanSelectSaveFile))]
@@ -87,20 +92,20 @@ public partial class LandingViewModel : ViewModelBase
             return;
         }
 
-        var hasError = await EstablishDbConnection(filePath, false);
-        HandleDatabaseConnection(hasError);
+        var connectionResult = await EstablishDbConnection(filePath, false);
+        HandleDatabaseConnection(connectionResult);
     }
 
-    private void HandleDatabaseConnection(bool hasError)
+    private void HandleDatabaseConnection(OneOf<Success, Error> connectionResult)
     {
-        if (hasError) return;
+        if (connectionResult.TryPickT1(out _, out _)) return;
 
         MessageBox.Show("Successfully connected to SMB3 database at " +
                         $"{Environment.NewLine}{_dataService.CurrentFilePath}");
         _navigationService.NavigateTo<HomeViewModel>();
     }
 
-    private async Task<bool> EstablishDbConnection(string filePath, bool isCompressedSaveGame = true)
+    private async Task<OneOf<Success, Error>> EstablishDbConnection(string filePath, bool isCompressedSaveGame = true)
     {
         var hasError = false;
         var connectionResult = await _dataService.EstablishDbConnection(filePath, isCompressedSaveGame);
@@ -114,7 +119,7 @@ public partial class LandingViewModel : ViewModelBase
 
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Arrow);
         
-        return hasError;
+        return !hasError ? new Success() : new Error();
     }
 
     protected override void Dispose(bool disposing)

--- a/SMB3Explorer/ViewModels/MainWindowViewModel.cs
+++ b/SMB3Explorer/ViewModels/MainWindowViewModel.cs
@@ -36,6 +36,8 @@ public partial class MainWindowViewModel : ViewModelBase
         _dataService = dataService;
         _httpService = httpService;
         
+        Log.Information("Initializing MainWindowViewModel");
+        
         _dataService.ConnectionChanged += DataServiceOnConnectionChanged;
     }
 

--- a/SMB3Explorer/ViewModels/MainWindowViewModel.cs
+++ b/SMB3Explorer/ViewModels/MainWindowViewModel.cs
@@ -152,8 +152,7 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private Task SubmitBugReport()
     {
-        const string bugUrl = "https://github.com/tbrittain/SMB3Explorer/issues/new?labels=bug&template=bug_report.md";
-        SafeProcess.Start(bugUrl, _systemIoWrapper);
+        SafeProcess.Start(DefaultExceptionHandler.GithubNewBugUrl, _systemIoWrapper);
         return Task.CompletedTask;
     }
 

--- a/SMB3Explorer/ViewModels/MainWindowViewModel.cs
+++ b/SMB3Explorer/ViewModels/MainWindowViewModel.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
-using OneOf.Types;
+using Serilog;
 using SMB3Explorer.Models.Internal;
 using SMB3Explorer.Services.DataService;
 using SMB3Explorer.Services.HttpClient;
@@ -106,70 +106,102 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private Task OpenExportsFolder()
     {
+        Log.Information("Opening exports folder");
+        
         var defaultDirectory = CsvUtils.DefaultDirectory;
 
         if (!_systemIoWrapper.DirectoryExists(defaultDirectory))
         {
+            Log.Debug("Exports folder does not exist, creating");
             _systemIoWrapper.DirectoryCreate(defaultDirectory);
         }
 
         SafeProcess.Start(defaultDirectory, _systemIoWrapper);
+        
+        Log.Information("Opened exports folder");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task OpenWiki()
     {
+        Log.Information("Opening wiki");
+        
         const string wikiUrl = "https://github.com/tbrittain/SMB3Explorer/wiki";
         SafeProcess.Start(wikiUrl, _systemIoWrapper);
+        
+        Log.Information("Opened wiki");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task SubmitFeatureRequest()
     {
+        Log.Information("Opening feature request page");
+        
         const string featureRequestUrl = "https://github.com/tbrittain/SMB3Explorer/discussions/new?category=ideas";
         SafeProcess.Start(featureRequestUrl, _systemIoWrapper);
+        
+        Log.Information("Opened feature request page");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task OpenDiscussions()
     {
+        Log.Information("Opening discussions page");
+        
         const string discussionsUrl = "https://github.com/tbrittain/SMB3Explorer/discussions";
         SafeProcess.Start(discussionsUrl, _systemIoWrapper);
+        
+        Log.Information("Opened discussions page");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task OpenIssues()
     {
+        Log.Information("Opening issues page");
+        
         const string issuesUrl = "https://github.com/tbrittain/SMB3Explorer/issues";
         SafeProcess.Start(issuesUrl, _systemIoWrapper);
+        
+        Log.Information("Opened issues page");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task SubmitBugReport()
     {
+        Log.Information("Opening bug report page");
+        
         SafeProcess.Start(DefaultExceptionHandler.GithubNewBugUrl, _systemIoWrapper);
+        
+        Log.Information("Opened bug report page");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private Task OpenGithubRepo()
     {
+        Log.Information("Opening github repo");
+        
         const string githubUrl = "https://github.com/tbrittain/SMB3Explorer";
         SafeProcess.Start(githubUrl, _systemIoWrapper);
+        
+        Log.Information("Opened github repo");
         return Task.CompletedTask;
     }
 
     [RelayCommand]
     private async Task PurgeApplicationData()
     {
+        Log.Information("Purging application data");
+        
         var appDataSummary = AppData.GetApplicationDataSize(_systemIoWrapper, _dataService.CurrentFilePath);
         if (appDataSummary.NumberOfFiles == 0)
         {
+            Log.Debug("No application data to delete");
             _systemIoWrapper.ShowMessageBox("No application data to delete.", "No Application Data",
                 MessageBoxButton.OK, MessageBoxImage.Information);
             return;
@@ -190,14 +222,17 @@ public partial class MainWindowViewModel : ViewModelBase
         
         if (failedPurgeResults.Count == 0)
         {
+            Log.Debug("All files deleted successfully");
             _systemIoWrapper.ShowMessageBox("All files deleted successfully.", "Success",
                 MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
 
+        Log.Warning("Failed to delete {Count} files", failedPurgeResults.Count);
         var failedMessage = new StringBuilder($"Failed to delete {failedPurgeResults.Count} files:");
         foreach (var _ in failedPurgeResults)
         {
+            Log.Warning("Failed to delete {FileName} ({Size})", _.FileName, _.Size.ToFileSizeString());
             failedMessage.AppendLine(
                 $"{Environment.NewLine}{_.FileName} ({_.Size.ToFileSizeString()})");
         }
@@ -209,12 +244,17 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private Task OpenUpdateVersionReleasePage()
     {
+        Log.Information("Opening update version release page");
+        
         SafeProcess.Start(AppUpdateResult!.Value.ReleasePageUrl, _systemIoWrapper);
+        
+        Log.Information("Opened update version release page");
         return Task.CompletedTask;
     }
 
     private async Task CheckForUpdates()
     {
+        Log.Information("Checking for updates...");
         var updateResult = await _httpService.CheckForUpdates();
 
         if (updateResult.TryPickT2(out var error, out var rest))
@@ -226,12 +266,14 @@ public partial class MainWindowViewModel : ViewModelBase
 
         if (rest.TryPickT1(out var _, out var appUpdateResult))
         {
+            Log.Debug("No update available");
             // No update available
             return;
         }
         
         AppUpdateResult = appUpdateResult;
         
+        Log.Debug("Displaying update available message box");
         var message = $"An update is available ({CurrentVersion} --> {appUpdateResult.Version}, released " +
                       $"{appUpdateResult.DaysSinceRelease} days ago). Would you like open the release page?";
 

--- a/SMB3ExplorerTests/UtilsTests/DefaultExceptionHandlerTests.cs
+++ b/SMB3ExplorerTests/UtilsTests/DefaultExceptionHandlerTests.cs
@@ -106,6 +106,6 @@ public class DefaultExceptionHandlerTests
         // Assert
         mockSystemIoWrapper.Verify(
             m => m.StartProcess(It.Is<ProcessStartInfo>(p =>
-                p.Arguments.Contains(DefaultExceptionHandler.GithubNewIssueUrl))), Times.Once);
+                p.Arguments.Contains(DefaultExceptionHandler.GithubNewBugUrl))), Times.Once);
     }
 }


### PR DESCRIPTION
- Add logging (debug, info, warn, etc.) throughout the app using Serilog
- Log to console and also to a file in %appdata%\SMB3Explorer\Logs\ each time program launched
  - On error, DefaultExceptionHandler flushes the current log and restarts it, then optionally opens the log folder and the Github issue template
- Add global exception handling in App.xaml.cs
- Closes #29 