### PR TITLE
Add season schedule export

### DIFF
--- a/SMB3Explorer/Models/Exports/SeasonSchedule.cs
+++ b/SMB3Explorer/Models/Exports/SeasonSchedule.cs
@@ -1,0 +1,24 @@
+﻿using CsvHelper.Configuration.Attributes;
+
+namespace SMB3Explorer.Models.Exports;
+
+public class SeasonSchedule
+{
+    [Name("season_id"), Index(0)]
+    public int SeasonId { get; set; }
+    
+    [Name("season_num"), Index(1)]
+    public int SeasonNum { get; set; }
+    
+    [Name("game_num"), Index(2)]
+    public int GameNum { get; set; }
+    
+    [Name("day"), Index(3)]
+    public int Day { get; set; }
+    
+    [Name("home_team"), Index(4)]
+    public string HomeTeam { get; set; } = string.Empty;
+    
+    [Name("away_team"), Index(5)]
+    public string AwayTeam { get; set; } = string.Empty;
+}

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonSchedule.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonSchedule.sql
@@ -1,3 +1,5 @@
+-- The t_season_schedule table apparently only tracks the current season for the given league,
+-- so the usage of this will be restricted to the current season
 WITH teams AS
          (SELECT ttli.GUID AS teamGUID, ttli.localID, tt.teamName
           FROM t_team_local_ids ttli

--- a/SMB3Explorer/Resources/Sql/SeasonSchedules.sql
+++ b/SMB3Explorer/Resources/Sql/SeasonSchedules.sql
@@ -1,0 +1,27 @@
+WITH teams AS
+         (SELECT ttli.GUID AS teamGUID, ttli.localID, tt.teamName
+          FROM t_team_local_ids ttli
+                   JOIN t_teams tt ON ttli.GUID = tt.GUID
+                   JOIN t_division_teams t on tt.GUID = t.teamGUID
+                   JOIN t_divisions d on t.divisionGUID = d.GUID
+                   JOIN t_conferences c on d.conferenceGUID = c.GUID
+                   JOIN t_leagues l on c.leagueGUID = l.GUID
+                   JOIN t_franchise tf ON l.GUID = tf.leagueGUID
+          WHERE l.GUID = CAST(@leagueId AS BLOB)),
+     seasons AS (SELECT id AS seasonID, RANK() OVER (ORDER BY id) AS seasonNum
+                 FROM t_seasons
+                          JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
+                          JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
+                 WHERE t_leagues.GUID = CAST(@leagueId AS BLOB))
+SELECT tss.seasonID,
+       s.seasonNum,
+       RANK() OVER (PARTITION BY tss.seasonID ORDER BY rowid) as gameNumber,
+       (ROW_NUMBER() OVER (PARTITION BY tss.seasonID ORDER BY rowid) - 1) /
+       ((SELECT COUNT(*) FROM teams) / 2) + 1                 AS day,
+       homeTeams.teamName                                     AS homeTeam,
+       awayTeams.teamName                                     AS awayTeam
+FROM t_season_schedule tss
+         JOIN seasons s ON tss.seasonID = s.seasonID
+         JOIN teams homeTeams ON tss.homeTeamID = homeTeams.localID
+         JOIN teams awayTeams ON tss.awayTeamID = awayTeams.localID
+ORDER BY tss.seasonID, gameNumber;

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -95,6 +95,8 @@
       <EmbeddedResource Include="Resources\Sql\SeasonAverageBatterStats.sql" />
       <None Remove="Resources\Sql\SeasonAveragePitcherStats.sql" />
       <EmbeddedResource Include="Resources\Sql\SeasonAveragePitcherStats.sql" />
+      <None Remove="Resources\Sql\MostRecentSeasonSchedule.sql" />
+      <EmbeddedResource Include="Resources\Sql\MostRecentSeasonSchedule.sql" />
     </ItemGroup>
 
 </Project>

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -188,6 +188,11 @@ public partial class DataService
         }
     }
 
+    public IAsyncEnumerable<SeasonSchedule> GetMostRecentSeasonSchedule()
+    {
+        throw new NotImplementedException();
+    }
+
     private async Task<double> GetAverageSeasonOps()
     {
         var command = Connection!.CreateCommand();

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -188,9 +188,33 @@ public partial class DataService
         }
     }
 
-    public IAsyncEnumerable<SeasonSchedule> GetMostRecentSeasonSchedule()
+    public async IAsyncEnumerable<SeasonSchedule> GetMostRecentSeasonSchedule()
     {
-        throw new NotImplementedException();
+        var command = Connection!.CreateCommand();
+        
+        var commandText = SqlRunner.GetSqlCommand(SqlFile.MostRecentSeasonSchedule);
+        command.CommandText = commandText;
+        
+        command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
+        {
+            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+        });
+        
+        var reader = await command.ExecuteReaderAsync();
+
+        while (reader.Read())
+        {
+            var seasonSchedule = new SeasonSchedule();
+            
+            seasonSchedule.SeasonId = reader.GetInt32(0);
+            seasonSchedule.SeasonNum = reader.GetInt32(1);
+            seasonSchedule.GameNum = reader.GetInt32(2);
+            seasonSchedule.Day = reader.GetInt32(3);
+            seasonSchedule.HomeTeam = reader.GetString(4);
+            seasonSchedule.AwayTeam = reader.GetString(5);
+            
+            yield return seasonSchedule;
+        }
     }
 
     private async Task<double> GetAverageSeasonOps()

--- a/SMB3Explorer/Services/DataService/IDataService.cs
+++ b/SMB3Explorer/Services/DataService/IDataService.cs
@@ -34,4 +34,5 @@ public interface IDataService
 
     IAsyncEnumerable<SeasonPlayer> GetMostRecentSeasonPlayers();
     IAsyncEnumerable<SeasonTeam> GetMostRecentSeasonTeams();
+    IAsyncEnumerable<SeasonSchedule> GetMostRecentSeasonSchedule();
 }

--- a/SMB3Explorer/Utils/CsvUtils.cs
+++ b/SMB3Explorer/Utils/CsvUtils.cs
@@ -39,11 +39,7 @@ public static class CsvUtils
         {
             await csv.WriteRecordAsync(enumerator.Current);
 
-            if (rowCount >= limit)
-            {
-                break;
-            }
-
+            if (rowCount >= limit) break;
             rowCount++;
         }
         

--- a/SMB3Explorer/Utils/SqlRunner.cs
+++ b/SMB3Explorer/Utils/SqlRunner.cs
@@ -74,6 +74,9 @@ public enum SqlFile
     
     [Description("SeasonAveragePitcherStats.sql")]
     SeasonAveragePitcherStats,
+    
+    [Description("MostRecentSeasonSchedule.sql")]
+    MostRecentSeasonSchedule,
 }
 
 public static class SqlRunner

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -123,6 +123,7 @@ public partial class HomeViewModel : ViewModelBase
                     
                     ExportMostRecentSeasonPlayersCommand.NotifyCanExecuteChanged();
                     ExportMostRecentSeasonTeamsCommand.NotifyCanExecuteChanged();
+                    ExportMostRecentSeasonScheduleCommand.NotifyCanExecuteChanged();
                 });
 
                 break;
@@ -359,6 +360,22 @@ public partial class HomeViewModel : ViewModelBase
                        $"_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
         
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, teamsEnumerable, fileName);
+        
+        HandleExportSuccess(filePath);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExport))]
+    private async Task ExportMostRecentSeasonSchedule()
+    {
+        Mouse.OverrideCursor = Cursors.Wait;
+        
+        var scheduleEnumerable = _dataService.GetMostRecentSeasonSchedule();
+        
+        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
+        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_schedule" +
+                       $"_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
+        
+        var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, scheduleEnumerable, fileName);
         
         HandleExportSuccess(filePath);
     }

--- a/SMB3Explorer/Views/HomeView.xaml
+++ b/SMB3Explorer/Views/HomeView.xaml
@@ -151,7 +151,7 @@
                 </WrapPanel>
             </GroupBox>
             
-            <GroupBox Header="Most Recent Season"
+            <GroupBox Header="Current Season"
                       Grid.Row="1"
                       Grid.Column="2">
                 <WrapPanel Orientation="Vertical"
@@ -162,7 +162,7 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportTopPerformersBattingCommand}"
-                        Content="Export most recent season top batters" />
+                        Content="Export current season top batters" />
                     
                     <Button
                         Margin="0, 5, 0, 0"
@@ -170,7 +170,7 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportTopPerformersPitchingCommand}"
-                        Content="Export most recent season top pitchers" />
+                        Content="Export current season top pitchers" />
                     
                     <Button
                         Margin="0, 5, 0, 0"
@@ -178,7 +178,7 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportTopRookiesBattingCommand}"
-                        Content="Export most recent season top rookie batters" />
+                        Content="Export current season top rookie batters" />
                     
                     <Button
                         Margin="0, 5, 0, 0"
@@ -186,7 +186,7 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportTopRookiesPitchingCommand}"
-                        Content="Export most recent season top rookie pitchers" />
+                        Content="Export current season top rookie pitchers" />
                     
                     <Button
                         Margin="0, 5, 0, 0"
@@ -194,7 +194,7 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportMostRecentSeasonPlayersCommand}"
-                        Content="Export most recent season players" />
+                        Content="Export current season players" />
                     
                     <Button
                         Margin="0, 5, 0, 0"
@@ -202,7 +202,15 @@
                         HorizontalAlignment="Stretch"
                         Height="50"
                         Command="{Binding ExportMostRecentSeasonTeamsCommand}"
-                        Content="Export most recent season teams" />
+                        Content="Export current season teams" />
+                    
+                    <Button
+                        Margin="0, 5, 0, 0"
+                        Padding="5"
+                        HorizontalAlignment="Stretch"
+                        Height="50"
+                        Command="{Binding ExportMostRecentSeasonScheduleCommand}"
+                        Content="Export current season schedule" />
                 </WrapPanel>
             </GroupBox>
 


### PR DESCRIPTION
- Add season schedule export
  - Includes enumerating the individual games, as well as marking games as occurring on specific days of the season
  - Only applies to most recent season (limitation of the game not tracking previous season schedules to my knowledge)
Closes #86 