### PR TITLE
Rudimentary SMB4 compatibility; JSON config with previously selected SMB4 leagues

### DIFF
--- a/SMB3Explorer/App.xaml.cs
+++ b/SMB3Explorer/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using SMB3Explorer.AppConfig;
 using SMB3Explorer.Services.ApplicationContext;
 using SMB3Explorer.Services.CsvWriterWrapper;
 using SMB3Explorer.Services.DataService;
@@ -50,6 +51,7 @@ public partial class App
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<IApplicationContext, ApplicationContext>();
         services.AddSingleton<ISystemIoWrapper, SystemIoWrapper>();
+        services.AddSingleton<IAppConfig, AppConfig.AppConfig>();
 
         services.AddSingleton<MainWindow>(serviceProvider => new MainWindow
         {

--- a/SMB3Explorer/App.xaml.cs
+++ b/SMB3Explorer/App.xaml.cs
@@ -51,7 +51,7 @@ public partial class App
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<IApplicationContext, ApplicationContext>();
         services.AddSingleton<ISystemIoWrapper, SystemIoWrapper>();
-        services.AddSingleton<IAppConfig, AppConfig.AppConfig>();
+        services.AddSingleton<IApplicationConfig, ApplicationConfig>();
 
         services.AddSingleton<MainWindow>(serviceProvider => new MainWindow
         {

--- a/SMB3Explorer/AppConfig/AppConfig.cs
+++ b/SMB3Explorer/AppConfig/AppConfig.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+using OneOf;
+using OneOf.Types;
+using Serilog;
+using SMB3Explorer.AppConfig.Models;
+using SMB3Explorer.Constants;
+
+namespace SMB3Explorer.AppConfig;
+
+public class AppConfig : IAppConfig
+{
+    private const string ConfigFileName = "config.json";
+
+    public OneOf<ConfigOptions, Error<string>> GetConfigOptions()
+    {
+        var configFilePath = Path.Combine(FileExports.ConfigDirectory, ConfigFileName);
+        if (File.Exists(configFilePath))
+        {
+            var configJson = File.ReadAllText(configFilePath);
+            var config = JsonConvert.DeserializeObject<ConfigOptions>(configJson);
+            if (config is not null) return config;
+
+            Log.Error("Failed to deserialize config file");
+            return new Error<string>("Failed to deserialize config file.");
+        }
+
+        var configOptions = new ConfigOptions();
+        SaveConfigOptions(configOptions);
+        return configOptions;
+    }
+
+    public OneOf<Success, Error<string>> SaveConfigOptions(ConfigOptions configOptions)
+    {
+        var configFilePath = Path.Combine(FileExports.ConfigDirectory, ConfigFileName);
+        var configJson = JsonConvert.SerializeObject(configOptions, Formatting.Indented);
+        try
+        {
+            File.WriteAllText(configFilePath, configJson);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Failed to save config file");
+            return new Error<string>("Failed to save config file.");
+        }
+
+        return new Success();
+    }
+}

--- a/SMB3Explorer/AppConfig/ApplicationConfig.cs
+++ b/SMB3Explorer/AppConfig/ApplicationConfig.cs
@@ -34,6 +34,20 @@ public class ApplicationConfig : IApplicationConfig
     public OneOf<Success, Error<string>> SaveConfigOptions(ConfigOptions configOptions)
     {
         var configFilePath = Path.Combine(FileExports.ConfigDirectory, ConfigFileName);
+
+        if (!Directory.Exists(FileExports.ConfigDirectory))
+        {
+            try
+            {
+                Directory.CreateDirectory(FileExports.ConfigDirectory);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Failed to create config directory");
+                return new Error<string>("Failed to create config directory.");
+            }
+        }
+
         var configJson = JsonConvert.SerializeObject(configOptions, Formatting.Indented);
         try
         {

--- a/SMB3Explorer/AppConfig/ApplicationConfig.cs
+++ b/SMB3Explorer/AppConfig/ApplicationConfig.cs
@@ -9,7 +9,7 @@ using SMB3Explorer.Constants;
 
 namespace SMB3Explorer.AppConfig;
 
-public class AppConfig : IAppConfig
+public class ApplicationConfig : IApplicationConfig
 {
     private const string ConfigFileName = "config.json";
 

--- a/SMB3Explorer/AppConfig/IAppConfig.cs
+++ b/SMB3Explorer/AppConfig/IAppConfig.cs
@@ -1,0 +1,11 @@
+﻿using OneOf;
+using OneOf.Types;
+using SMB3Explorer.AppConfig.Models;
+
+namespace SMB3Explorer.AppConfig;
+
+public interface IAppConfig
+{
+    OneOf<ConfigOptions, Error<string>> GetConfigOptions();
+    OneOf<Success, Error<string>> SaveConfigOptions(ConfigOptions configOptions);
+}

--- a/SMB3Explorer/AppConfig/IApplicationConfig.cs
+++ b/SMB3Explorer/AppConfig/IApplicationConfig.cs
@@ -4,7 +4,7 @@ using SMB3Explorer.AppConfig.Models;
 
 namespace SMB3Explorer.AppConfig;
 
-public interface IAppConfig
+public interface IApplicationConfig
 {
     OneOf<ConfigOptions, Error<string>> GetConfigOptions();
     OneOf<Success, Error<string>> SaveConfigOptions(ConfigOptions configOptions);

--- a/SMB3Explorer/AppConfig/Models/ConfigOptions.cs
+++ b/SMB3Explorer/AppConfig/Models/ConfigOptions.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SMB3Explorer.AppConfig.Models;
+
+public class ConfigOptions
+{
+    [JsonProperty("smb4Leagues")]
+    public List<League> Leagues { get; set; } = new();
+}

--- a/SMB3Explorer/AppConfig/Models/League.cs
+++ b/SMB3Explorer/AppConfig/Models/League.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace SMB3Explorer.AppConfig.Models;
+
+public class League
+{
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+    
+    [JsonProperty("id")]
+    public Guid Id { get; set; }
+}

--- a/SMB3Explorer/Constants/FileExports.cs
+++ b/SMB3Explorer/Constants/FileExports.cs
@@ -7,11 +7,13 @@ public static class FileExports
 {
     public static readonly string BaseGameDirectoryPath = Path.Combine(Environment.GetFolderPath(
         Environment.SpecialFolder.LocalApplicationData), "Metalhead", "Super Mega Baseball 3");
-    
+
     public static readonly string BaseExportsDirectory =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMB3Explorer");
-    
+
     public static readonly string LogDirectory = Path.Combine(BaseExportsDirectory, "Logs");
+
+    public static readonly string ConfigDirectory = Path.Combine(BaseExportsDirectory, "Config");
 
     public static readonly string TempDirectory = Path.GetTempPath();
 }

--- a/SMB3Explorer/Constants/FileExports.cs
+++ b/SMB3Explorer/Constants/FileExports.cs
@@ -5,7 +5,10 @@ namespace SMB3Explorer.Constants;
 
 public static class FileExports
 {
-    public static readonly string BaseGameDirectoryPath = Path.Combine(Environment.GetFolderPath(
+    public static readonly string BaseGameSmb4DirectoryPath = Path.Combine(Environment.GetFolderPath(
+        Environment.SpecialFolder.LocalApplicationData), "Metalhead", "Super Mega Baseball 4");
+
+    public static readonly string BaseGameSmb3DirectoryPath = Path.Combine(Environment.GetFolderPath(
         Environment.SpecialFolder.LocalApplicationData), "Metalhead", "Super Mega Baseball 3");
 
     public static readonly string BaseExportsDirectory =

--- a/SMB3Explorer/Converters/EnumToBooleanConverter.cs
+++ b/SMB3Explorer/Converters/EnumToBooleanConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SMB3Explorer.Converters;
+
+public class EnumToBooleanConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value.Equals(parameter);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return (bool)value ? parameter : Binding.DoNothing;
+    }
+}

--- a/SMB3Explorer/Enums/SelectedGame.cs
+++ b/SMB3Explorer/Enums/SelectedGame.cs
@@ -1,0 +1,7 @@
+﻿namespace SMB3Explorer.Enums;
+
+public enum SelectedGame
+{
+    Smb3,
+    Smb4
+}

--- a/SMB3Explorer/Models/Exports/CareerPitchingStatistic.cs
+++ b/SMB3Explorer/Models/Exports/CareerPitchingStatistic.cs
@@ -10,12 +10,12 @@ namespace SMB3Explorer.Models.Exports;
 public class CareerPitchingStatistic : CareerStatistic
 {
     [Ignore]
-    public int PitcherRole { get; set; }
+    public int? PitcherRole { get; set; }
     
     [Name("Pitcher Role"), Index(7)]
     // ReSharper disable once UnusedMember.Global
-    public string PitcherRoleDescription => ((PitcherRole) PitcherRole).GetEnumDescription();
-    
+    public string? PitcherRoleDescription => PitcherRole is null ? null : ((PitcherRole) PitcherRole).GetEnumDescription();
+
     [Name("W"), Index(8)]
     public int Wins { get; set; }
     

--- a/SMB3Explorer/Models/Exports/PitchingStatistic.cs
+++ b/SMB3Explorer/Models/Exports/PitchingStatistic.cs
@@ -35,12 +35,12 @@ public abstract class PitchingStatistic
     public int PositionNumber { get; set; }
     
     [Ignore]
-    public int PitcherRole { get; set; }
+    public int? PitcherRole { get; set; }
 
     [Name("Pitcher Role"), Index(6)]
     // ReSharper disable once UnusedMember.Global
-    public string PitcherRoleDescription => ((PitcherRole) PitcherRole).GetEnumDescription();
-    
+    public string? PitcherRoleDescription => PitcherRole is null ? null : ((PitcherRole) PitcherRole).GetEnumDescription();
+
     [Name("Age"), Index(7)]
     public int Age { get; set; }
 

--- a/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
+++ b/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace SMB3Explorer.Models.Internal;
+
+public record Smb4LeagueSelection(string LeagueName, Guid LeagueId);

--- a/SMB3Explorer/Resources/Sql/GetLeagues.sql
+++ b/SMB3Explorer/Resources/Sql/GetLeagues.sql
@@ -1,3 +1,4 @@
-﻿SELECT GUID AS LeagueId, name AS LeagueName
+﻿SELECT name AS LeagueName
 FROM t_leagues
-WHERE originalGUID IS NULL;
+WHERE originalGUID IS NULL
+LIMIT 1;

--- a/SMB3Explorer/Resources/Sql/GetLeagues.sql
+++ b/SMB3Explorer/Resources/Sql/GetLeagues.sql
@@ -1,0 +1,3 @@
+﻿SELECT GUID AS LeagueId, name AS LeagueName
+FROM t_leagues
+WHERE originalGUID IS NULL;

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -97,6 +97,8 @@
       <EmbeddedResource Include="Resources\Sql\SeasonAveragePitcherStats.sql" />
       <None Remove="Resources\Sql\MostRecentSeasonSchedule.sql" />
       <EmbeddedResource Include="Resources\Sql\MostRecentSeasonSchedule.sql" />
+      <None Remove="Resources\Sql\GetLeagues.sql" />
+      <EmbeddedResource Include="Resources\Sql\GetLeagues.sql" />
     </ItemGroup>
 
 </Project>

--- a/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
@@ -41,6 +41,8 @@ public sealed class ApplicationContext : IApplicationContext, INotifyPropertyCha
 
     public SelectedGame SelectedGame { get; set; }
 
+    public string? MostRecentSelectedSaveFilePath { get; set; }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using SMB3Explorer.Enums;
 using SMB3Explorer.Models.Internal;
 
 namespace SMB3Explorer.Services.ApplicationContext;
@@ -37,6 +38,8 @@ public sealed class ApplicationContext : IApplicationContext, INotifyPropertyCha
         get => _franchiseSeasonsLoading;
         set => SetField(ref _franchiseSeasonsLoading, value);
     }
+
+    public SelectedGame SelectedGame { get; set; }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.ComponentModel;
+using SMB3Explorer.Enums;
 using SMB3Explorer.Models.Internal;
 
 namespace SMB3Explorer.Services.ApplicationContext;
@@ -11,5 +12,6 @@ public interface IApplicationContext
     ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; }
     FranchiseSeason? MostRecentFranchiseSeason { get; set; }
     bool FranchiseSeasonsLoading { get; set; }
+    SelectedGame SelectedGame { get; set; }
     event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
@@ -13,5 +13,6 @@ public interface IApplicationContext
     FranchiseSeason? MostRecentFranchiseSeason { get; set; }
     bool FranchiseSeasonsLoading { get; set; }
     SelectedGame SelectedGame { get; set; }
+    string? MostRecentSelectedSaveFilePath { get; set; }
     event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseCareer.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseCareer.cs
@@ -111,7 +111,10 @@ public partial class DataService
 
             pitcher.Age = int.Parse(reader["age"].ToString()!);
 
-            pitcher.PitcherRole = int.Parse(reader["pitcherRole"].ToString()!);
+            pitcher.PitcherRole = string.IsNullOrEmpty(reader["pitcherRole"].ToString())
+                ? null
+                : int.Parse(reader["pitcherRole"].ToString()!);
+
             pitcher.Wins = int.Parse(reader["wins"].ToString()!);
             pitcher.Losses = int.Parse(reader["losses"].ToString()!);
             pitcher.GamesPlayed = int.Parse(reader["games"].ToString()!);

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
@@ -116,9 +116,11 @@ public partial class DataService
         pitcherStatistic.PreviousTeamName = string.IsNullOrEmpty(reader["previousRecentlyPlayedTeamName"].ToString()!)
             ? null
             : reader["previousRecentlyPlayedTeamName"].ToString()!;
-        
-        pitcherStatistic.PitcherRole = 
-            int.Parse(reader["pitcherRole"].ToString()!);
+
+        pitcherStatistic.PitcherRole = string.IsNullOrEmpty(reader["pitcherRole"].ToString()!)
+            ? null
+            : int.Parse(reader["pitcherRole"].ToString()!);
+
         pitcherStatistic.GamesPlayed = int.Parse(reader["games"].ToString()!);
         pitcherStatistic.GamesStarted = int.Parse(reader["gamesStarted"].ToString()!);
         pitcherStatistic.Wins = int.Parse(reader["wins"].ToString()!);

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -115,7 +115,7 @@ public partial class DataService
             mostRecentSeasonStatistic.FirstName = reader.GetString(3);
             mostRecentSeasonStatistic.LastName = reader.GetString(4);
             mostRecentSeasonStatistic.PositionNumber = reader.GetInt32(5);
-            mostRecentSeasonStatistic.PitcherRole = reader.GetInt32(6);
+            mostRecentSeasonStatistic.PitcherRole = reader.IsDBNull(6) ? null : reader.GetInt32(6);
             mostRecentSeasonStatistic.Wins = reader.GetInt32(8);
             mostRecentSeasonStatistic.Losses = reader.GetInt32(9);
             mostRecentSeasonStatistic.GamesStarted = reader.GetInt32(11);

--- a/SMB3Explorer/Services/DataService/IDataService.cs
+++ b/SMB3Explorer/Services/DataService/IDataService.cs
@@ -13,7 +13,7 @@ public interface IDataService
 {
     bool IsConnected { get; }
     Task<OneOf<string, Error<string>>> DecompressSaveGame(string filePath, ISystemIoWrapper systemIoWrapper);
-    Task<OneOf<Success, Error<string>>> EstablishDbConnection(string filePath, bool isCompressedSaveGame = true);
+    Task<OneOf<List<Smb4LeagueSelection>, Error<string>>> EstablishDbConnection(string filePath, bool isCompressedSaveGame = true);
     Task<List<FranchiseSelection>> GetFranchises();
     Task<List<FranchiseSeason>> GetFranchiseSeasons();
 

--- a/SMB3Explorer/Utils/SqlRunner.cs
+++ b/SMB3Explorer/Utils/SqlRunner.cs
@@ -77,6 +77,9 @@ public enum SqlFile
     
     [Description("MostRecentSeasonSchedule.sql")]
     MostRecentSeasonSchedule,
+    
+    [Description("GetLeagues.sql")]
+    GetLeagues,
 }
 
 public static class SqlRunner

--- a/SMB3Explorer/ViewModels/LandingViewModel.cs
+++ b/SMB3Explorer/ViewModels/LandingViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using OneOf;
 using OneOf.Types;
 using Serilog;
+using SMB3Explorer.Services.ApplicationContext;
 using SMB3Explorer.Services.DataService;
 using SMB3Explorer.Services.NavigationService;
 using SMB3Explorer.Services.SystemIoWrapper;
@@ -15,20 +16,52 @@ namespace SMB3Explorer.ViewModels;
 
 public partial class LandingViewModel : ViewModelBase
 {
+    // ReSharper disable once ConvertToConstant.Global
+    public static readonly string Smb3 = "SMB3";
+
+    // ReSharper disable once ConvertToConstant.Global
+    public static readonly string Smb4 = "SMB4";
     private readonly IDataService _dataService;
     private readonly INavigationService _navigationService;
     private readonly ISystemIoWrapper _systemIoWrapper;
+    private readonly IApplicationContext _applicationContext;
+    private string _selectedGame = Smb4;
 
-    public LandingViewModel(IDataService dataService, INavigationService navigationService, ISystemIoWrapper systemIoWrapper)
+    public LandingViewModel(IDataService dataService, INavigationService navigationService,
+        ISystemIoWrapper systemIoWrapper, IApplicationContext applicationContext)
     {
         _navigationService = navigationService;
         _systemIoWrapper = systemIoWrapper;
+        _applicationContext = applicationContext;
         _dataService = dataService;
-        
+
         Log.Information("Initializing LandingViewModel");
 
         _dataService.ConnectionChanged += DataServiceOnConnectionChanged;
     }
+
+    public string SelectedGame
+    {
+        get => _selectedGame;
+        set
+        {
+            SetField(ref _selectedGame, value);
+            _applicationContext.SelectedGame = value switch
+            {
+                "SMB3" => Enums.SelectedGame.Smb3,
+                "SMB4" => Enums.SelectedGame.Smb4,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+            };
+            
+            OnPropertyChanged(nameof(Smb3ButtonVisibility));
+            OnPropertyChanged(nameof(Smb4ButtonVisibility));
+        }
+    }
+
+    private bool IsSmb3Selected => SelectedGame == Smb3;
+    
+    public Visibility Smb3ButtonVisibility => IsSmb3Selected ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility Smb4ButtonVisibility => IsSmb3Selected ? Visibility.Collapsed : Visibility.Visible;
 
     private void DataServiceOnConnectionChanged(object? sender, EventArgs e)
     {
@@ -47,14 +80,14 @@ public partial class LandingViewModel : ViewModelBase
     {
         Mouse.OverrideCursor = Cursors.Wait;
 
-        var filePathResult =  SaveFile.GetSaveFilePath(_systemIoWrapper);
+        var filePathResult = SaveFile.GetSaveFilePath(_systemIoWrapper);
         if (filePathResult.TryPickT1(out _, out var filePath) || string.IsNullOrEmpty(filePath))
         {
             // TODO: Handle error
             Mouse.OverrideCursor = Cursors.Arrow;
             return;
         }
-        
+
         var connectionResult = await EstablishDbConnection(filePath);
         HandleDatabaseConnection(connectionResult);
     }
@@ -109,7 +142,7 @@ public partial class LandingViewModel : ViewModelBase
     {
         var hasError = false;
         var connectionResult = await _dataService.EstablishDbConnection(filePath, isCompressedSaveGame);
-        
+
         if (connectionResult.TryPickT1(out var error, out _))
         {
             hasError = true;
@@ -118,7 +151,7 @@ public partial class LandingViewModel : ViewModelBase
         }
 
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Arrow);
-        
+
         return !hasError ? new Success() : new Error();
     }
 

--- a/SMB3Explorer/Views/LandingView.xaml
+++ b/SMB3Explorer/Views/LandingView.xaml
@@ -4,8 +4,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:SMB3Explorer.ViewModels"
+             xmlns:enums="clr-namespace:SMB3Explorer.Enums"
+             xmlns:converters="clr-namespace:SMB3Explorer.Converters"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance viewModels:LandingViewModel}">
+    <UserControl.Resources>
+        <converters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+    </UserControl.Resources>
     <StackPanel HorizontalAlignment="Center"
                 VerticalAlignment="Center">
         <Label FontSize="25"
@@ -18,10 +23,31 @@
             Foreground="Red"
             Content="Note: To ensure your game is not corrupted, do NOT use this tool if the game is running." />
 
-        <ComboBox SelectedItem="{Binding SelectedGame}">
-            <ComboBoxItem Content="{x:Static viewModels:LandingViewModel.Smb3}" />
-            <ComboBoxItem Content="{x:Static viewModels:LandingViewModel.Smb4}" />
-        </ComboBox>
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+            <Label Content="Select game version:" />
+            <StackPanel Orientation="Horizontal">
+                <RadioButton
+                    GroupName="Options"
+                    Content="SMB3">
+                    <RadioButton.IsChecked>
+                        <Binding 
+                            Path="SelectedGame" 
+                            Converter="{StaticResource EnumToBooleanConverter}"
+                            ConverterParameter="{x:Static enums:SelectedGame.Smb3}" />
+                    </RadioButton.IsChecked>
+                </RadioButton>
+                <RadioButton 
+                    GroupName="Options"
+                    Content="SMB4">
+                    <RadioButton.IsChecked>
+                        <Binding 
+                            Path="SelectedGame" 
+                            Converter="{StaticResource EnumToBooleanConverter}"
+                            ConverterParameter="{x:Static enums:SelectedGame.Smb4}" />
+                    </RadioButton.IsChecked>
+                </RadioButton>
+            </StackPanel>
+        </StackPanel>
 
         <StackPanel Orientation="Horizontal"
                     HorizontalAlignment="Center"
@@ -29,10 +55,20 @@
                     Margin="0,10,0,0">
 
             <!-- TODO Command for handling this -->
+
+            <StackPanel Orientation="Vertical" Visibility="{Binding Smb4ButtonVisibility}">
+                <Label Content="Select an existing SMB4 save:" />
+                <ComboBox
+                    Width="200"
+                    ItemsSource="{Binding Smb4LeagueSelections}"
+                    DisplayMemberPath="Name" />
+            </StackPanel>
+
             <Button
+                Margin="10,0,0,0"
                 Visibility="{Binding Smb4ButtonVisibility}"
-                Width="250"
-                Content="Use most recent SMB4 league save file" />
+                Width="100"
+                Content="Load Save Game" />
 
             <Button
                 Visibility="{Binding Smb3ButtonVisibility}"

--- a/SMB3Explorer/Views/LandingView.xaml
+++ b/SMB3Explorer/Views/LandingView.xaml
@@ -11,33 +11,49 @@
         <Label FontSize="25"
                FontWeight="Bold"
                HorizontalAlignment="Center"
-               Content="Welcome to SMB3 Explorer! Please select a save file to begin." />
+               Content="Welcome to SMB Explorer! Please select a save file to begin." />
         <Label
             HorizontalAlignment="Center"
             FontSize="18"
             Foreground="Red"
             Content="Note: To ensure your game is not corrupted, do NOT use this tool if the game is running." />
 
+        <ComboBox SelectedItem="{Binding SelectedGame}">
+            <ComboBoxItem Content="{x:Static viewModels:LandingViewModel.Smb3}" />
+            <ComboBoxItem Content="{x:Static viewModels:LandingViewModel.Smb4}" />
+        </ComboBox>
+
         <StackPanel Orientation="Horizontal"
                     HorizontalAlignment="Center"
                     Height="50"
                     Margin="0,10,0,0">
+
+            <!-- TODO Command for handling this -->
             <Button
+                Visibility="{Binding Smb4ButtonVisibility}"
+                Width="250"
+                Content="Use most recent SMB4 league save file" />
+
+            <Button
+                Visibility="{Binding Smb3ButtonVisibility}"
                 Command="{Binding AutomaticallySelectSaveFileCommand}"
                 Width="200"
                 Content="Automatically detect save file" />
 
-            <Label VerticalAlignment="Center" Margin="5">
+            <Label
+                Visibility="{Binding Smb3ButtonVisibility}"
+                VerticalAlignment="Center"
+                Margin="5">
                 -or-
             </Label>
 
             <Button Width="200"
-                Content="Manually select save file"
-                Command="{Binding ManuallySelectSaveFileCommand}">
+                    Content="Manually select save file"
+                    Command="{Binding ManuallySelectSaveFileCommand}">
                 <Button.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Use an existing save file database"
-                                  Command="{Binding UseExistingDatabaseCommand}"/>
+                                  Command="{Binding UseExistingDatabaseCommand}" />
                     </ContextMenu>
                 </Button.ContextMenu>
             </Button>

--- a/SMB3Explorer/Views/LandingView.xaml
+++ b/SMB3Explorer/Views/LandingView.xaml
@@ -54,17 +54,18 @@
                     Height="50"
                     Margin="0,10,0,0">
 
-            <!-- TODO Command for handling this -->
-
             <StackPanel Orientation="Vertical" Visibility="{Binding Smb4ButtonVisibility}">
                 <Label Content="Select an existing SMB4 save:" />
                 <ComboBox
+                    SelectedItem="{Binding SelectedExistingLeague}"
                     Width="200"
                     ItemsSource="{Binding Smb4LeagueSelections}"
-                    DisplayMemberPath="Name" />
+                    DisplayMemberPath="LeagueName" />
             </StackPanel>
 
             <Button
+                Command="{Binding ConnectToPreviouslyConnectedSaveGameCommand}"
+                IsEnabled="{Binding AtLeastOneExistingLeague}"
                 Margin="10,0,0,0"
                 Visibility="{Binding Smb4ButtonVisibility}"
                 Width="100"
@@ -77,7 +78,6 @@
                 Content="Automatically detect save file" />
 
             <Label
-                Visibility="{Binding Smb3ButtonVisibility}"
                 VerticalAlignment="Center"
                 Margin="5">
                 -or-

--- a/SMB3ExplorerTests/UtilsTests/SaveFileTests.cs
+++ b/SMB3ExplorerTests/UtilsTests/SaveFileTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using Microsoft.Win32;
 using Moq;
+using SMB3Explorer.Enums;
 using SMB3Explorer.Services.SystemIoWrapper;
 using SMB3Explorer.Utils;
 using static SMB3Explorer.Constants.FileExports;
@@ -54,13 +55,13 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
-        var steamDirectory = Path.Combine(BaseGameDirectoryPath, "123456");
+        var steamDirectory = Path.Combine(BaseGameSmb3DirectoryPath, "123456");
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(new[] {steamDirectory});
 
         var saveFilePath =
@@ -71,7 +72,7 @@ public class SaveFileTests
             .Returns(true);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -86,7 +87,7 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(false);
 
         mockSystemIoWrapper.Setup(x =>
@@ -97,7 +98,7 @@ public class SaveFileTests
             .Returns(true);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -112,7 +113,7 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(false);
 
         mockSystemIoWrapper.Setup(x =>
@@ -120,7 +121,7 @@ public class SaveFileTests
             .Returns(MessageBoxResult.No);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -135,13 +136,13 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
-        var steamDirectory = Path.Combine(BaseGameDirectoryPath, "123456");
+        var steamDirectory = Path.Combine(BaseGameSmb3DirectoryPath, "123456");
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(new[] {steamDirectory});
 
         var saveFilePath =
@@ -159,7 +160,7 @@ public class SaveFileTests
             .Returns(true);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -174,13 +175,13 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
-        var steamDirectory = Path.Combine(BaseGameDirectoryPath, "123456");
+        var steamDirectory = Path.Combine(BaseGameSmb3DirectoryPath, "123456");
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(new[] {steamDirectory});
 
         var saveFilePath =
@@ -195,7 +196,7 @@ public class SaveFileTests
             .Returns(MessageBoxResult.No);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -210,11 +211,11 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(Array.Empty<string>());
 
         mockSystemIoWrapper.Setup(x =>
@@ -225,7 +226,7 @@ public class SaveFileTests
             .Returns(true);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -240,11 +241,11 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(Array.Empty<string>());
 
         mockSystemIoWrapper.Setup(x =>
@@ -252,7 +253,7 @@ public class SaveFileTests
             .Returns(MessageBoxResult.No);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -267,14 +268,14 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
-        var steamDirectory1 = Path.Combine(BaseGameDirectoryPath, "123456");
-        var steamDirectory2 = Path.Combine(BaseGameDirectoryPath, "654321");
+        var steamDirectory1 = Path.Combine(BaseGameSmb3DirectoryPath, "123456");
+        var steamDirectory2 = Path.Combine(BaseGameSmb3DirectoryPath, "654321");
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(new[] {steamDirectory1, steamDirectory2});
 
         var saveFilePath1 =
@@ -299,7 +300,7 @@ public class SaveFileTests
             .Returns(true);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();
@@ -314,14 +315,14 @@ public class SaveFileTests
         var mockSystemIoWrapper = new Mock<ISystemIoWrapper>(MockBehavior.Strict);
         
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryExists(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryExists(BaseGameSmb3DirectoryPath))
             .Returns(true);
 
-        var steamDirectory1 = Path.Combine(BaseGameDirectoryPath, "123456");
-        var steamDirectory2 = Path.Combine(BaseGameDirectoryPath, "654321");
+        var steamDirectory1 = Path.Combine(BaseGameSmb3DirectoryPath, "123456");
+        var steamDirectory2 = Path.Combine(BaseGameSmb3DirectoryPath, "654321");
 
         mockSystemIoWrapper
-            .Setup(x => x.DirectoryGetDirectories(BaseGameDirectoryPath))
+            .Setup(x => x.DirectoryGetDirectories(BaseGameSmb3DirectoryPath))
             .Returns(new[] {steamDirectory1, steamDirectory2});
 
         var saveFilePath1 =
@@ -343,7 +344,7 @@ public class SaveFileTests
             .Returns(MessageBoxResult.No);
         
         // Act
-        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object);
+        var result = SaveFile.GetSaveFilePath(mockSystemIoWrapper.Object, SelectedGame.Smb3);
         
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
- Add toggling between SMB3 and SMB4 mode in landing page
- Add JSON config that caches previously selected SMB4 leagues for ease of selection on landing page
- Fix some issues with the CSV schema that caused issues when using some pitcher exports in SMB4 (notably pitcher role, since now position players can pitch, leading to this issue)

Closes #117 