### PR TITLE
Season and Elimination exports

### DIFF
--- a/SMB3Explorer/ApplicationConfig/ApplicationConfig.cs
+++ b/SMB3Explorer/ApplicationConfig/ApplicationConfig.cs
@@ -12,6 +12,10 @@ namespace SMB3Explorer.ApplicationConfig;
 public class ApplicationConfig : IApplicationConfig
 {
     private const string ConfigFileName = "config.json";
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        WriteIndented = true
+    };
 
     public OneOf<ConfigOptions, Error<string>> GetConfigOptions()
     {
@@ -51,11 +55,7 @@ public class ApplicationConfig : IApplicationConfig
             }
         }
 
-        var configJson = JsonSerializer.Serialize(configOptions,
-            new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            });
+        var configJson = JsonSerializer.Serialize(configOptions, JsonSerializerOptions);
 
         try
         {

--- a/SMB3Explorer/ApplicationConfig/ApplicationConfig.cs
+++ b/SMB3Explorer/ApplicationConfig/ApplicationConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 using OneOf;
 using OneOf.Types;
 using Serilog;
@@ -19,8 +19,11 @@ public class ApplicationConfig : IApplicationConfig
         if (File.Exists(configFilePath))
         {
             var configJson = File.ReadAllText(configFilePath);
-            var config = JsonConvert.DeserializeObject<ConfigOptions>(configJson);
-            if (config is not null) return config;
+            var config = JsonSerializer.Deserialize<ConfigOptions>(configJson);
+            if (config is not null)
+            {
+                return config;
+            }
 
             Log.Error("Failed to deserialize config file");
             return new Error<string>("Failed to deserialize config file.");
@@ -48,7 +51,12 @@ public class ApplicationConfig : IApplicationConfig
             }
         }
 
-        var configJson = JsonConvert.SerializeObject(configOptions, Formatting.Indented);
+        var configJson = JsonSerializer.Serialize(configOptions,
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+            });
+
         try
         {
             File.WriteAllText(configFilePath, configJson);

--- a/SMB3Explorer/ApplicationConfig/Models/ConfigOptions.cs
+++ b/SMB3Explorer/ApplicationConfig/Models/ConfigOptions.cs
@@ -10,5 +10,5 @@ public class ConfigOptions
     public SelectedGame GamePreference { get; set; } = SelectedGame.Smb4;
 
     [JsonPropertyName("smb4Leagues")]
-    public List<League> Leagues { get; set; } = new();
+    public List<League> Leagues { get; init; } = [];
 }

--- a/SMB3Explorer/ApplicationConfig/Models/ConfigOptions.cs
+++ b/SMB3Explorer/ApplicationConfig/Models/ConfigOptions.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using SMB3Explorer.Enums;
 
 namespace SMB3Explorer.ApplicationConfig.Models;
 
 public class ConfigOptions
 {
-    [JsonProperty("gamePreference")]
+    [JsonPropertyName("gamePreference")]
     public SelectedGame GamePreference { get; set; } = SelectedGame.Smb4;
 
-    [JsonProperty("smb4Leagues")]
+    [JsonPropertyName("smb4Leagues")]
     public List<League> Leagues { get; set; } = new();
 }

--- a/SMB3Explorer/ApplicationConfig/Models/League.cs
+++ b/SMB3Explorer/ApplicationConfig/Models/League.cs
@@ -6,23 +6,23 @@ namespace SMB3Explorer.ApplicationConfig.Models;
 public class League
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 
     [JsonPropertyName("id")]
-    public Guid Id { get; set; }
+    public Guid Id { get; init; }
 
     [JsonPropertyName("playerTeam")]
-    public string? PlayerTeam { get; set; }
+    public string? PlayerTeam { get; init; }
     
     [JsonPropertyName("numSeasons")]
-    public int? NumSeasons { get; set; }
+    public int? NumSeasons { get; init; }
     
     [JsonPropertyName("numTimesAccessed")]
-    public int NumTimesAccessed { get; set; }
+    public int NumTimesAccessed { get; init; }
 
     [JsonPropertyName("firstAccessed")]
-    public DateTime FirstAccessed { get; set; }
+    public DateTime FirstAccessed { get; init; }
 
     [JsonPropertyName("lastAccessed")]
-    public DateTime LastAccessed { get; set; }
+    public DateTime LastAccessed { get; init; }
 }

--- a/SMB3Explorer/ApplicationConfig/Models/League.cs
+++ b/SMB3Explorer/ApplicationConfig/Models/League.cs
@@ -1,28 +1,28 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace SMB3Explorer.ApplicationConfig.Models;
 
 public class League
 {
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public Guid Id { get; set; }
 
-    [JsonProperty("playerTeam")]
+    [JsonPropertyName("playerTeam")]
     public string? PlayerTeam { get; set; }
     
-    [JsonProperty("numSeasons")]
+    [JsonPropertyName("numSeasons")]
     public int? NumSeasons { get; set; }
     
-    [JsonProperty("numTimesAccessed")]
+    [JsonPropertyName("numTimesAccessed")]
     public int NumTimesAccessed { get; set; }
 
-    [JsonProperty("firstAccessed")]
+    [JsonPropertyName("firstAccessed")]
     public DateTime FirstAccessed { get; set; }
 
-    [JsonProperty("lastAccessed")]
+    [JsonPropertyName("lastAccessed")]
     public DateTime LastAccessed { get; set; }
 }

--- a/SMB3Explorer/ApplicationConfig/Models/League.cs
+++ b/SMB3Explorer/ApplicationConfig/Models/League.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using SMB3Explorer.Models.Internal;
 
 namespace SMB3Explorer.ApplicationConfig.Models;
 
@@ -10,6 +11,9 @@ public class League
 
     [JsonPropertyName("id")]
     public Guid Id { get; init; }
+
+    [JsonPropertyName("mode")]
+    public LeagueMode? Mode { get; init; }
 
     [JsonPropertyName("playerTeam")]
     public string? PlayerTeam { get; init; }

--- a/SMB3Explorer/Enums/PitchTypes.cs
+++ b/SMB3Explorer/Enums/PitchTypes.cs
@@ -1,11 +1,38 @@
 ﻿using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
+
 // ReSharper disable NotAccessedPositionalProperty.Global
 
 namespace SMB3Explorer.Enums;
 
-public record struct DatabaseIntOption(int OptionKey, int OptionValue);
+public record DatabaseIntOption
+{
+    [JsonConstructor]
+    public DatabaseIntOption()
+    {
+        // For JSON deserialization only
+    }
+
+    public DatabaseIntOption(int optionKey, int optionValue)
+    {
+        OptionKey = optionKey;
+        OptionValue = optionValue;
+    }
+
+    [JsonPropertyName("optionKey")]
+    // ReSharper disable once MemberCanBePrivate.Global
+    // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+    public int OptionKey { get; init; }
+
+    [JsonPropertyName("optionValue")]
+    // ReSharper disable once MemberCanBePrivate.Global
+    // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+    public int OptionValue { get; init; }
+
+    override public string ToString() => $"{OptionKey}:{OptionValue}";
+}
 
 public class PitchTypes
 {

--- a/SMB3Explorer/Enums/PitchTypes.cs
+++ b/SMB3Explorer/Enums/PitchTypes.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.ComponentModel;
 // ReSharper disable NotAccessedPositionalProperty.Global
 
@@ -37,8 +37,8 @@ public class PitchTypes
         {new DatabaseIntOption(65, 1), PitchType.Cutter}
     };
 
-    public static ImmutableDictionary<DatabaseIntOption, PitchType?> Pitches =>
-        _pitches.ToImmutableDictionary();
+    public static FrozenDictionary<DatabaseIntOption, PitchType?> Pitches =>
+        _pitches.ToFrozenDictionary();
 }
 
 public enum PitchType

--- a/SMB3Explorer/Enums/PlayerTrait.cs
+++ b/SMB3Explorer/Enums/PlayerTrait.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 // ReSharper disable NotAccessedPositionalProperty.Global
 
@@ -8,7 +9,30 @@ namespace SMB3Explorer.Enums;
 
 public static class PlayerTrait
 {
-    public record struct DatabaseTraitSubtypePair(int TraitId, int? SubtypeId);
+    public record DatabaseTraitSubtypePair
+    {
+        [JsonConstructor]
+        public DatabaseTraitSubtypePair()
+        {
+            // For JSON deserialization only
+        }
+
+        public DatabaseTraitSubtypePair(int traitId, int? subtypeId)
+        {
+            TraitId = traitId;
+            SubtypeId = subtypeId;
+        }
+
+        [JsonPropertyName("traitId")]
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+        public int TraitId { get; init; }
+
+        [JsonPropertyName("subtypeId")]
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+        public int? SubtypeId { get; init; }
+    }
 
     // ReSharper disable once InconsistentNaming
     private static Dictionary<DatabaseTraitSubtypePair, Trait> _smb3TraitMap { get; } = new()

--- a/SMB3Explorer/Enums/PlayerTrait.cs
+++ b/SMB3Explorer/Enums/PlayerTrait.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 // ReSharper disable NotAccessedPositionalProperty.Global
@@ -35,8 +35,8 @@ public static class PlayerTrait
         {new DatabaseTraitSubtypePair(9, null), Trait.BatterUtility},
     };
 
-    public static ImmutableDictionary<DatabaseTraitSubtypePair, Trait> Smb3TraitMap { get; } =
-        _smb3TraitMap.ToImmutableDictionary();
+    public static FrozenDictionary<DatabaseTraitSubtypePair, Trait> Smb3TraitMap { get; } =
+        _smb3TraitMap.ToFrozenDictionary();
 
     // ReSharper disable once InconsistentNaming
     private static Dictionary<DatabaseTraitSubtypePair, Trait> _smb4TraitMap { get; } = new()
@@ -118,8 +118,8 @@ public static class PlayerTrait
         {new DatabaseTraitSubtypePair(40, 6), Trait.BatterBunter},
     };
 
-    public static ImmutableDictionary<DatabaseTraitSubtypePair, Trait> Smb4TraitMap { get; } =
-        _smb4TraitMap.ToImmutableDictionary();
+    public static FrozenDictionary<DatabaseTraitSubtypePair, Trait> Smb4TraitMap { get; } =
+        _smb4TraitMap.ToFrozenDictionary();
 }
 
 public enum Trait

--- a/SMB3Explorer/Models/Internal/FranchiseSelection.cs
+++ b/SMB3Explorer/Models/Internal/FranchiseSelection.cs
@@ -1,8 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace SMB3Explorer.Models.Internal;
+
+public enum LeagueMode
+{
+    Franchise,
+    Season,
+    Elimination
+}
 
 public record FranchiseSelection
 {
@@ -10,15 +18,49 @@ public record FranchiseSelection
         .Concat(Path.GetInvalidFileNameChars())
         .ToArray();
     
-    public Guid LeagueId { get; init; }
-    public Guid FranchiseId { get; init; }
-    public string LeagueName { get; init; } = string.Empty;
-    public string LeagueType { get; init; } = string.Empty;
-    public string PlayerTeamName { get; init; } = string.Empty;
-    public int NumSeasons { get; init; }
+    private string? _displayText;
 
+    public required Guid LeagueId { get; init; }
+    public required LeagueMode Mode { get; init; }
+    public required string LeagueName { get; init; } = string.Empty;
+    public required string LeagueType { get; init; } = string.Empty;
+    public required string? PlayerTeamName { get; init; } = string.Empty;
+    public required int NumSeasons { get; init; }
+    
     // ReSharper disable once UnusedMember.Global
-    public string DisplayText => $"{LeagueName}: {NumSeasons} seasons as {PlayerTeamName}";
+    public string DisplayText
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(_displayText))
+            {
+                return _displayText;
+            }
+
+            var sb = new StringBuilder(LeagueName);
+
+            switch (Mode)
+            {
+                case LeagueMode.Franchise:
+                    sb.Append($": Franchise mode ({LeagueType}) with {NumSeasons} seasons");
+                    if (!string.IsNullOrEmpty(PlayerTeamName))
+                    {
+                        sb.Append($" as {PlayerTeamName}");
+                    }
+                    break;
+                case LeagueMode.Season:
+                    sb.Append($": Season mode ({LeagueType}) with {NumSeasons} seasons");
+                    break;
+                case LeagueMode.Elimination:
+                    sb.Append($": Elimination mode ({LeagueType})");
+                    break;
+            }
+
+            _displayText = sb.ToString();
+
+            return _displayText;
+        }
+    }
 
     public string LeagueNameSafe => new(LeagueName
         .Select(c => _invalidChars

--- a/SMB3Explorer/Models/Internal/FranchiseSelection.cs
+++ b/SMB3Explorer/Models/Internal/FranchiseSelection.cs
@@ -7,6 +7,10 @@ namespace SMB3Explorer.Models.Internal;
 
 public enum LeagueMode
 {
+    /// <summary>
+    /// This may be the case if no games have been played yet
+    /// </summary>
+    None,
     Franchise,
     Season,
     Elimination
@@ -53,6 +57,9 @@ public record FranchiseSelection
                     break;
                 case LeagueMode.Elimination:
                     sb.Append($": Elimination mode ({LeagueType})");
+                    break;
+                case LeagueMode.None:
+                    sb.Append($": No games played yet ({LeagueType})");
                     break;
             }
 

--- a/SMB3Explorer/Models/Internal/GitHubReleaseResponse.cs
+++ b/SMB3Explorer/Models/Internal/GitHubReleaseResponse.cs
@@ -1,24 +1,24 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace SMB3Explorer.Models.Internal;
 
 public class GitHubReleaseResponse
 {
-    [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public int Id { get; set; }
 
-    [JsonProperty("tag_name")]
+    [JsonPropertyName("tag_name")]
     public string TagName { private get; set; } = string.Empty;
     
-    [JsonProperty("html_url")]
+    [JsonPropertyName("html_url")]
     public string HtmlUrl { get; set; } = string.Empty;
     
     public Version Version => Version.Parse(TagName.TrimStart('v'));
     
-    [JsonProperty("published_at")]
+    [JsonPropertyName("published_at")]
     public DateTime PublishedAt { get; set; }
     
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }

--- a/SMB3Explorer/Models/Internal/LeagueSelection.cs
+++ b/SMB3Explorer/Models/Internal/LeagueSelection.cs
@@ -16,7 +16,7 @@ public enum LeagueMode
     Elimination
 }
 
-public record FranchiseSelection
+public record LeagueSelection
 {
     private readonly char[] _invalidChars = new[] {' '}
         .Concat(Path.GetInvalidFileNameChars())

--- a/SMB3Explorer/Models/Internal/LeagueSelection.cs
+++ b/SMB3Explorer/Models/Internal/LeagueSelection.cs
@@ -16,6 +16,20 @@ public enum LeagueMode
     Elimination
 }
 
+public static class LeagueModeExtensions
+{
+    public static LeagueMode Parse(bool hasFranchise, bool? isElimination)
+    {
+        return (hasFranchise, isElimination) switch
+        {
+            (true, _) => LeagueMode.Franchise,
+            (false, true) => LeagueMode.Elimination,
+            (false, false) => LeagueMode.Season,
+            _ => LeagueMode.None
+        };
+    }
+}
+
 public record LeagueSelection
 {
     private readonly char[] _invalidChars = new[] {' '}
@@ -53,7 +67,7 @@ public record LeagueSelection
                     }
                     break;
                 case LeagueMode.Season:
-                    sb.Append($": Season mode ({LeagueType}) with {NumSeasons} seasons");
+                    sb.Append($": Season mode ({LeagueType})");
                     break;
                 case LeagueMode.Elimination:
                     sb.Append($": Elimination mode ({LeagueType})");

--- a/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
+++ b/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
@@ -17,6 +17,11 @@ public record Smb4LeagueSelection(string LeagueName, Guid SaveGameLeagueId, stri
         {
             var sb = new StringBuilder(LeagueName);
 
+            if (Mode is not null)
+            {
+                sb.Append($" ({Mode} mode)");
+            }
+
             if (!string.IsNullOrEmpty(PlayerTeam) && NumSeasons is not null)
             {
                 sb.Append($" ({NumSeasons} seasons as {PlayerTeam})");

--- a/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
+++ b/SMB3Explorer/Models/Internal/Smb4LeagueSelection.cs
@@ -6,8 +6,9 @@ namespace SMB3Explorer.Models.Internal;
 public record Smb4LeagueSelection(string LeagueName, Guid SaveGameLeagueId, string? PlayerTeam, int? NumSeasons)
 {
     public int NumTimesAccessed { get; set; }
-    public DateTime FirstAccessed { get; set; }
+    public DateTime FirstAccessed { get; init; }
     public DateTime LastAccessed { get; set; }
+    public LeagueMode? Mode { get; init; }
     
     // ReSharper disable once UnusedMember.Global
     public string DisplayName
@@ -34,7 +35,7 @@ public record Smb4LeagueSelection(string LeagueName, Guid SaveGameLeagueId, stri
                PlayerTeam == other.PlayerTeam;
     }
 
-    public override int GetHashCode()
+    override public int GetHashCode()
     {
         return HashCode.Combine(LeagueName, SaveGameLeagueId, PlayerTeam);
     }

--- a/SMB3Explorer/Resources/Sql/FranchisePlayoffStandings.sql
+++ b/SMB3Explorer/Resources/Sql/FranchisePlayoffStandings.sql
@@ -1,9 +1,7 @@
-﻿WITH franchiseSeasons AS
+﻿WITH leagueSeasons AS
          (SELECT ts.*
-          FROM t_franchise tf
-                   JOIN t_leagues tl ON tf.leagueGUID = tl.GUID
-                   LEFT JOIN t_franchise_seasons tfs ON tf.GUID = tfs.franchiseGUID
-                   LEFT JOIN t_seasons ts ON tfs.seasonGUID = ts.GUID
+          FROM t_seasons ts
+                   JOIN t_leagues tl ON ts.historicalLeagueGUID = tl.GUID
           WHERE tl.GUID = CAST(@leagueId AS BLOB)
           GROUP BY ts.ID),
      seasonPlayoffs AS (SELECT ts.ID AS seasonID,
@@ -28,18 +26,18 @@
                                  JOIN t_playoffs tp ON tp.GUID = vpgwl1.playoffGUID
                                  JOIN t_seasons ts ON ts.GUID = tp.seasonGUID)
 SELECT ROW_NUMBER() OVER (
-    ORDER BY fs.ID, gamesWon DESC
-    )                                AS `index`,
-       fs.ID                         AS seasonID,
-       DENSE_RANK() OVER (ORDER BY fs.ID  ) AS seasonNum,
+    ORDER BY ls.ID, gamesWon DESC
+    )                                      AS `index`,
+       ls.ID                               AS seasonID,
+       DENSE_RANK() OVER (ORDER BY ls.ID ) AS seasonNum,
        vss.*,
-       vss.runsFor - vss.runsAgainst AS runDifferential,
-       tc.name                       AS conferenceName,
-       td.name                       AS divisionName,
-       tt.teamName                   AS teamName
+       vss.runsFor - vss.runsAgainst       AS runDifferential,
+       tc.name                             AS conferenceName,
+       td.name                             AS divisionName,
+       tt.teamName                         AS teamName
 FROM seasonPlayoffs vss
-         JOIN franchiseSeasons fs ON vss.seasonID = fs.ID
+         JOIN leagueSeasons ls ON vss.seasonID = ls.ID
          JOIN t_conferences tc ON vss.conferenceGUID = tc.GUID
          JOIN t_divisions td ON vss.divisionGUID = td.GUID
          JOIN t_teams tt ON vss.teamGUID = tt.GUID
-ORDER BY fs.ID, gamesWon DESC
+ORDER BY ls.ID, gamesWon DESC

--- a/SMB3Explorer/Resources/Sql/FranchiseSeasonStandings.sql
+++ b/SMB3Explorer/Resources/Sql/FranchiseSeasonStandings.sql
@@ -1,24 +1,22 @@
-﻿WITH franchiseSeasons AS
+﻿WITH leagueSeasons AS
          (SELECT ts.*
-          FROM t_franchise tf
-                   JOIN t_leagues tl ON tf.leagueGUID = tl.GUID
-                   LEFT JOIN t_franchise_seasons tfs ON tf.GUID = tfs.franchiseGUID
-                   LEFT JOIN t_seasons ts ON tfs.seasonGUID = ts.GUID
+          FROM t_seasons ts
+                   JOIN t_leagues tl ON ts.historicalLeagueGUID = tl.GUID
           WHERE tl.GUID = CAST(@leagueId AS BLOB)
           GROUP BY ts.ID)
 SELECT ROW_NUMBER() OVER (
-    ORDER BY fs.ID, vss.conferenceGUID, vss.divisionGUID, vss.gamesBack, vss.runsFor - vss.runsAgainst DESC
-    )                                AS `index`,
-       fs.ID                         AS seasonID,
-       DENSE_RANK() OVER (ORDER BY fs.ID  ) AS seasonNum,
+    ORDER BY ls.ID, vss.conferenceGUID, vss.divisionGUID, vss.gamesBack, vss.runsFor - vss.runsAgainst DESC
+    )                                      AS `index`,
+       ls.ID                               AS seasonID,
+       DENSE_RANK() OVER (ORDER BY ls.ID ) AS seasonNum,
        vss.*,
-       vss.runsFor - vss.runsAgainst AS runDifferential,
-       tc.name                       AS conferenceName,
-       td.name                       AS divisionName,
-       tt.teamName                   AS teamName
+       vss.runsFor - vss.runsAgainst       AS runDifferential,
+       tc.name                             AS conferenceName,
+       td.name                             AS divisionName,
+       tt.teamName                         AS teamName
 FROM v_season_standings vss
-         JOIN franchiseSeasons fs ON vss.seasonGUID = fs.GUID
+         JOIN leagueSeasons ls ON vss.seasonGUID = ls.GUID
          JOIN t_conferences tc ON vss.conferenceGUID = tc.GUID
          JOIN t_divisions td ON vss.divisionGUID = td.GUID
          JOIN t_teams tt ON vss.teamGUID = tt.GUID
-ORDER BY fs.ID, vss.conferenceGUID, vss.divisionGUID, vss.gamesBack, runDifferential DESC
+ORDER BY ls.ID, vss.conferenceGUID, vss.divisionGUID, vss.gamesBack, runDifferential DESC

--- a/SMB3Explorer/Resources/Sql/FranchiseSeasons.sql
+++ b/SMB3Explorer/Resources/Sql/FranchiseSeasons.sql
@@ -1,8 +1,7 @@
-﻿SELECT id                        AS seasonID,
-       historicalLeagueGUID      AS leagueGUID,
-       RANK() OVER (ORDER BY id) AS seasonNum
-FROM t_seasons
-         JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-         JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
-WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
+﻿SELECT ts.id                        AS seasonID,
+       ts.historicalLeagueGUID      AS leagueGUID,
+       RANK() OVER (ORDER BY ts.id) AS seasonNum
+FROM t_seasons ts
+         JOIN t_leagues tl ON ts.historicalLeagueGUID = tl.GUID
+WHERE tl.GUID = CAST(@leagueId AS BLOB)
 ORDER BY ID DESC

--- a/SMB3Explorer/Resources/Sql/Franchises.sql
+++ b/SMB3Explorer/Resources/Sql/Franchises.sql
@@ -1,12 +1,12 @@
-﻿SELECT tl.GUID               AS leagueId,
-       tl.name               AS leagueName,
-       tl.allowedTeamType    AS leagueTeamTypeId,
-       ttt.typeName          AS leagueTypeName,
-       tf.GUID               AS franchiseId,
-       tf.playerTeamGUID     AS playerTeamId,
-       tt.teamName           AS playerTeamName,
-       COUNT(tfs.seasonGUID) AS numSeasons,
-       MAX(ts.elimination)   AS elimination
+﻿SELECT tl.GUID                     AS leagueId,
+       tl.name                     AS leagueName,
+       tl.allowedTeamType          AS leagueTeamTypeId,
+       ttt.typeName                AS leagueTypeName,
+       tf.GUID                     AS franchiseId,
+       tf.playerTeamGUID           AS playerTeamId,
+       tt.teamName                 AS playerTeamName,
+       SQRT(COUNT(tfs.seasonGUID)) AS numSeasons,
+       MAX(ts.elimination)         AS elimination
 FROM t_leagues tl
          LEFT JOIN t_franchise tf ON tl.GUID = tf.leagueGUID
          LEFT JOIN t_franchise_seasons tfs ON tf.GUID = tfs.franchiseGUID

--- a/SMB3Explorer/Resources/Sql/Franchises.sql
+++ b/SMB3Explorer/Resources/Sql/Franchises.sql
@@ -5,11 +5,13 @@
        tf.GUID               AS franchiseId,
        tf.playerTeamGUID     AS playerTeamId,
        tt.teamName           AS playerTeamName,
-       COUNT(tfs.seasonGUID) AS numSeasons
+       COUNT(tfs.seasonGUID) AS numSeasons,
+       MAX(ts.elimination)   AS elimination
 FROM t_leagues tl
-         JOIN t_franchise tf ON tl.GUID = tf.leagueGUID
-         JOIN t_franchise_seasons tfs ON tf.GUID = tfs.franchiseGUID
+         LEFT JOIN t_franchise tf ON tl.GUID = tf.leagueGUID
+         LEFT JOIN t_franchise_seasons tfs ON tf.GUID = tfs.franchiseGUID
          JOIN t_team_types ttt ON ttt.teamType = tl.allowedTeamType
-         JOIN t_teams tt ON tt.GUID = tf.playerTeamGUID
+         LEFT JOIN t_teams tt ON tt.GUID = tf.playerTeamGUID
+         LEFT JOIN t_seasons ts ON tl.GUID = ts.historicalLeagueGUID
 GROUP BY tl.GUID, tl.name, tf.GUID
 ORDER BY numSeasons DESC

--- a/SMB3Explorer/Resources/Sql/GetLeaguesForSmb4SaveGame.sql
+++ b/SMB3Explorer/Resources/Sql/GetLeaguesForSmb4SaveGame.sql
@@ -1,4 +1,8 @@
-﻿SELECT tl.name AS LeagueName, tt.teamName, COUNT(ts.GUID) AS NumSeasons
+﻿SELECT tl.name             AS LeagueName,
+       tt.teamName,
+       COUNT(ts.GUID)      AS NumSeasons,
+       MAX(ts.elimination) AS elimination,
+       tf.GUID             AS franchiseId
 FROM t_leagues tl
          LEFT JOIN t_franchise tf on tl.GUID = tf.leagueGUID
          LEFT JOIN t_teams tt on tf.playerTeamGUID = tt.GUID

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb3.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb3.sql
@@ -10,23 +10,23 @@
                           ORDER BY ID DESC
                           LIMIT 1)
 SELECT vbpi.baseballPlayerGUID,
-       tsea.ID                                        AS seasonId,
+       tsea.ID                                            AS seasonId,
        s.seasonNum,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[firstName]
-           ELSE vbpi.[firstName] END                  AS firstName,
+           ELSE vbpi.[firstName] END                      AS firstName,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[lastName]
-           ELSE vbpi.[lastName] END                   AS lastName,
+           ELSE vbpi.[lastName] END                       AS lastName,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[primaryPos]
-           ELSE vbpi.[primaryPosition] END            AS primaryPosition,
+           ELSE vbpi.[primaryPosition] END                AS primaryPosition,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[pitcherRole]
-           ELSE vbpi.[pitcherRole] END                AS pitcherRole,
-       CAST(secondaryPosition.optionValue AS INTEGER) AS secondaryPosition,
-       currentTeam.teamName                           AS currentTeam,
-       previousTeam.teamName                          AS previousTeam,
+           ELSE vbpi.[pitcherRole] END                    AS pitcherRole,
+       CAST(secondaryPosition.optionValue AS INTEGER)     AS secondaryPosition,
+       currentTeam.teamName                               AS currentTeam,
+       previousTeam.teamName                              AS previousTeam,
        tbp.power,
        tbp.contact,
        tbp.speed,
@@ -36,11 +36,11 @@ SELECT vbpi.baseballPlayerGUID,
        tbp.junk,
        tbp.accuracy,
        tbp.age,
-       salary.salary * 200                            AS salaryDollars,
+       IIF(salary.salary IS NULL, 0, salary.salary) * 200 AS salaryDollars,
        CASE
            WHEN COUNT(tbpt.trait) = 0 THEN NULL
            ELSE json_group_array(json_object('traitId', tbpt.trait, 'subtypeId', tbpt.subType))
-           END                                        AS traits
+           END                                            AS traits
 
 FROM [v_baseball_player_info] vbpi
          LEFT JOIN t_baseball_player_local_ids tbpli ON vbpi.baseballPlayerGUID = tbpli.GUID
@@ -55,7 +55,7 @@ FROM [v_baseball_player_info] vbpi
          JOIN t_league_local_ids tlli ON tsp.leagueLocalID = tlli.localID
          JOIN t_leagues tl ON tlli.GUID = tl.GUID
 
-         JOIN t_salary salary ON vbpi.baseballPlayerGUID = salary.baseballPlayerGUID
+         LEFT JOIN t_salary salary ON vbpi.baseballPlayerGUID = salary.baseballPlayerGUID
 
          LEFT JOIN t_baseball_player_options secondaryPosition
                    ON tbpli.localID = secondaryPosition.baseballPlayerLocalID AND secondaryPosition.optionKey = 55

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb3.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb3.sql
@@ -6,7 +6,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb4.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb4.sql
@@ -10,23 +10,23 @@
                           ORDER BY ID DESC
                           LIMIT 1)
 SELECT vbpi.baseballPlayerGUID,
-       tsea.ID                                        AS seasonId,
+       tsea.ID                                            AS seasonId,
        s.seasonNum,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[firstName]
-           ELSE vbpi.[firstName] END                  AS firstName,
+           ELSE vbpi.[firstName] END                      AS firstName,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[lastName]
-           ELSE vbpi.[lastName] END                   AS lastName,
+           ELSE vbpi.[lastName] END                       AS lastName,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[primaryPos]
-           ELSE vbpi.[primaryPosition] END            AS primaryPosition,
+           ELSE vbpi.[primaryPosition] END                AS primaryPosition,
        CASE
            WHEN tsp.[baseballPlayerLocalID] IS NULL THEN tsp.[pitcherRole]
-           ELSE vbpi.[pitcherRole] END                AS pitcherRole,
-       CAST(secondaryPosition.optionValue AS INTEGER) AS secondaryPosition,
-       currentTeam.teamName                           AS currentTeam,
-       previousTeam.teamName                          AS previousTeam,
+           ELSE vbpi.[pitcherRole] END                    AS pitcherRole,
+       CAST(secondaryPosition.optionValue AS INTEGER)     AS secondaryPosition,
+       currentTeam.teamName                               AS currentTeam,
+       previousTeam.teamName                              AS previousTeam,
        tbp.power,
        tbp.contact,
        tbp.speed,
@@ -36,11 +36,11 @@ SELECT vbpi.baseballPlayerGUID,
        tbp.junk,
        tbp.accuracy,
        tbp.age,
-       salary.salary * 200                            AS salaryDollars,
+       IIF(salary.salary IS NULL, 0, salary.salary) * 200 AS salaryDollars,
        CASE
            WHEN COUNT(tbpt.trait) = 0 THEN NULL
            ELSE json_group_array(json_object('traitId', tbpt.trait, 'subtypeId', tbpt.subType))
-           END                                        AS traits,
+           END                                            AS traits,
        CASE
            WHEN chemistry.optionValue = 0
                THEN 'Competitive'
@@ -53,20 +53,20 @@ SELECT vbpi.baseballPlayerGUID,
            WHEN chemistry.optionValue = 4
                THEN 'Crafty'
            ELSE 'Unknown'
-           END                                        AS chemistryType,
+           END                                            AS chemistryType,
        CASE
            WHEN throwHand.optionValue = 0 THEN 'L'
            WHEN throwHand.optionValue = 1 THEN 'R'
-           ELSE 'Unknown' END                         AS throwHand,
+           ELSE 'Unknown' END                             AS throwHand,
        CASE
            WHEN batHand.optionValue = 0 THEN 'L'
            WHEN batHand.optionValue = 1 THEN 'R'
            WHEN batHand.optionValue = 2 THEN 'S'
-           ELSE 'Unknown' END                         AS batHand,
+           ELSE 'Unknown' END                             AS batHand,
        CASE
            WHEN COUNT(pitches.optionValue) = 0 THEN NULL
            ELSE json_group_array(json_object('optionKey', pitches.optionKey, 'optionValue', pitches.optionValue))
-           END                                        AS pitches
+           END                                            AS pitches
 
 FROM [v_baseball_player_info] vbpi
          LEFT JOIN t_baseball_player_local_ids tbpli ON vbpi.baseballPlayerGUID = tbpli.GUID
@@ -81,7 +81,7 @@ FROM [v_baseball_player_info] vbpi
          JOIN t_league_local_ids tlli ON tsp.leagueLocalID = tlli.localID
          JOIN t_leagues tl ON tlli.GUID = tl.GUID
 
-         JOIN t_salary salary ON vbpi.baseballPlayerGUID = salary.baseballPlayerGUID
+         LEFT JOIN t_salary salary ON vbpi.baseballPlayerGUID = salary.baseballPlayerGUID
 
          LEFT JOIN t_baseball_player_options secondaryPosition
                    ON tbpli.localID = secondaryPosition.baseballPlayerLocalID AND secondaryPosition.optionKey = 55

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb4.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayersSmb4.sql
@@ -6,7 +6,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayoffSchedule.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonPlayoffSchedule.sql
@@ -6,14 +6,12 @@
                    JOIN t_divisions d on t.divisionGUID = d.GUID
                    JOIN t_conferences c on d.conferenceGUID = c.GUID
                    JOIN t_leagues l on c.leagueGUID = l.GUID
-                   JOIN t_franchise tf ON l.GUID = tf.leagueGUID
           WHERE l.GUID = CAST(@leagueId AS BLOB)),
      mostRecentSeason AS (SELECT id                        AS seasonID,
                                  t_seasons.GUID            AS seasonGUID,
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1),

--- a/SMB3Explorer/Resources/Sql/MostRecentSeasonSchedule.sql
+++ b/SMB3Explorer/Resources/Sql/MostRecentSeasonSchedule.sql
@@ -6,13 +6,11 @@ WITH teams AS
                    JOIN t_divisions d on t.divisionGUID = d.GUID
                    JOIN t_conferences c on d.conferenceGUID = c.GUID
                    JOIN t_leagues l on c.leagueGUID = l.GUID
-                   JOIN t_franchise tf ON l.GUID = tf.leagueGUID
           WHERE l.GUID = CAST(@leagueId AS BLOB)),
      mostRecentSeason AS (SELECT id                        AS seasonID,
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1),

--- a/SMB3Explorer/Resources/Sql/PlayoffsAverageBatterStats.sql
+++ b/SMB3Explorer/Resources/Sql/PlayoffsAverageBatterStats.sql
@@ -2,7 +2,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/PlayoffsAveragePitcherStats.sql
+++ b/SMB3Explorer/Resources/Sql/PlayoffsAveragePitcherStats.sql
@@ -2,7 +2,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/SeasonAverageBatterStats.sql
+++ b/SMB3Explorer/Resources/Sql/SeasonAverageBatterStats.sql
@@ -2,7 +2,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/SeasonAveragePitcherStats.sql
+++ b/SMB3Explorer/Resources/Sql/SeasonAveragePitcherStats.sql
@@ -2,7 +2,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/SeasonStatsBatting.sql
+++ b/SMB3Explorer/Resources/Sql/SeasonStatsBatting.sql
@@ -6,7 +6,6 @@
                         RANK() OVER (ORDER BY id) AS seasonNum
                  FROM t_seasons
                           JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                          JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                  WHERE t_leagues.GUID = CAST(@leagueId AS BLOB))
 SELECT ts.aggregatorID                     AS aggregatorID,
        ts.statsPlayerID                    AS statsPlayerID,

--- a/SMB3Explorer/Resources/Sql/SeasonStatsPitching.sql
+++ b/SMB3Explorer/Resources/Sql/SeasonStatsPitching.sql
@@ -6,7 +6,6 @@
                         RANK() OVER (ORDER BY id) AS seasonNum
                  FROM t_seasons
                           JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                          JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                  WHERE t_leagues.GUID = CAST(@leagueId AS BLOB))
 SELECT ts.aggregatorID                     AS aggregatorID,
        ts.statsPlayerID                    AS statsPlayerID,

--- a/SMB3Explorer/Resources/Sql/TopPerformersBatting.sql
+++ b/SMB3Explorer/Resources/Sql/TopPerformersBatting.sql
@@ -6,7 +6,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/TopPerformersBattingPlayoffs.sql
+++ b/SMB3Explorer/Resources/Sql/TopPerformersBattingPlayoffs.sql
@@ -6,7 +6,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/TopPerformersPitching.sql
+++ b/SMB3Explorer/Resources/Sql/TopPerformersPitching.sql
@@ -7,7 +7,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/Resources/Sql/TopPerformersPitchingPlayoffs.sql
+++ b/SMB3Explorer/Resources/Sql/TopPerformersPitchingPlayoffs.sql
@@ -7,7 +7,6 @@
                                  RANK() OVER (ORDER BY id) AS seasonNum
                           FROM t_seasons
                                    JOIN t_leagues ON t_seasons.historicalLeagueGUID = t_leagues.GUID
-                                   JOIN t_franchise tf ON t_leagues.GUID = tf.leagueGUID
                           WHERE t_leagues.GUID = CAST(@leagueId AS BLOB)
                           ORDER BY ID DESC
                           LIMIT 1)

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -25,7 +25,6 @@
       <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="OneOf" Version="3.0.271" />
       <PackageReference Include="Serilog" Version="4.2.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -22,7 +22,6 @@
     <ItemGroup>
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
       <PackageReference Include="CsvHelper" Version="30.0.1" />
-      <PackageReference Include="DotNetZip" Version="1.16.0" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.12" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />

--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <IsPackable>false</IsPackable>

--- a/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
@@ -16,16 +16,10 @@ public sealed class ApplicationContext : IApplicationContext, INotifyPropertyCha
     public FranchiseSelection? SelectedFranchise
     {
         get => _selectedFranchise;
-        set
-        {
-            SetField(ref _selectedFranchise, value);
-            OnPropertyChanged(nameof(IsFranchiseSelected));
-        }
+        set => SetField(ref _selectedFranchise, value);
     }
 
-    public bool IsFranchiseSelected => SelectedFranchise is not null;
-
-    public ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; } = new();
+    public ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; } = [];
 
     public FranchiseSeason? MostRecentFranchiseSeason
     {

--- a/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/ApplicationContext.cs
@@ -9,25 +9,25 @@ namespace SMB3Explorer.Services.ApplicationContext;
 
 public sealed class ApplicationContext : IApplicationContext, INotifyPropertyChanged
 {
-    private FranchiseSelection? _selectedFranchise;
+    private LeagueSelection? _selectedFranchise;
     private bool _franchiseSeasonsLoading;
     private FranchiseSeason? _mostRecentFranchiseSeason;
 
-    public FranchiseSelection? SelectedFranchise
+    public LeagueSelection? SelectedLeague
     {
         get => _selectedFranchise;
         set => SetField(ref _selectedFranchise, value);
     }
 
-    public ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; } = [];
+    public ConcurrentBag<FranchiseSeason> LeagueSeasons { get; } = [];
 
-    public FranchiseSeason? MostRecentFranchiseSeason
+    public FranchiseSeason? MostRecentLeagueSeason
     {
         get => _mostRecentFranchiseSeason;
         set => SetField(ref _mostRecentFranchiseSeason, value);
     }
 
-    public bool FranchiseSeasonsLoading
+    public bool LeagueSeasonsLoading
     {
         get => _franchiseSeasonsLoading;
         set => SetField(ref _franchiseSeasonsLoading, value);

--- a/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
@@ -7,10 +7,10 @@ namespace SMB3Explorer.Services.ApplicationContext;
 
 public interface IApplicationContext
 {
-    FranchiseSelection? SelectedFranchise { get; set; }
-    ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; }
-    FranchiseSeason? MostRecentFranchiseSeason { get; set; }
-    bool FranchiseSeasonsLoading { get; set; }
+    LeagueSelection? SelectedLeague { get; set; }
+    ConcurrentBag<FranchiseSeason> LeagueSeasons { get; }
+    FranchiseSeason? MostRecentLeagueSeason { get; set; }
+    bool LeagueSeasonsLoading { get; set; }
     SelectedGame SelectedGame { get; set; }
     event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
+++ b/SMB3Explorer/Services/ApplicationContext/IApplicationContext.cs
@@ -8,7 +8,6 @@ namespace SMB3Explorer.Services.ApplicationContext;
 public interface IApplicationContext
 {
     FranchiseSelection? SelectedFranchise { get; set; }
-    bool IsFranchiseSelected { get; }
     ConcurrentBag<FranchiseSeason> FranchiseSeasons { get; }
     FranchiseSeason? MostRecentFranchiseSeason { get; set; }
     bool FranchiseSeasonsLoading { get; set; }

--- a/SMB3Explorer/Services/DataService/DataService.cs
+++ b/SMB3Explorer/Services/DataService/DataService.cs
@@ -34,34 +34,34 @@ public sealed partial class DataService : INotifyPropertyChanged, IDataService
     {
         switch (e.PropertyName)
         {
-            case nameof(IApplicationContext.SelectedFranchise):
+            case nameof(IApplicationContext.SelectedLeague):
             {
-                if (_applicationContext.SelectedFranchise is null)
+                if (_applicationContext.SelectedLeague is null)
                 {
                     Log.Information("Clearing cached franchise seasons");
-                    _applicationContext.FranchiseSeasons.Clear();
-                    _applicationContext.MostRecentFranchiseSeason = null;
+                    _applicationContext.LeagueSeasons.Clear();
+                    _applicationContext.MostRecentLeagueSeason = null;
                     break;
                 }
 
                 Mouse.OverrideCursor = Cursors.Wait;
-                _applicationContext.FranchiseSeasonsLoading = true;
+                _applicationContext.LeagueSeasonsLoading = true;
                 Task.Run(async () =>
                 {
                     Log.Information("Setting cached franchise seasons");
                     var seasons = await GetFranchiseSeasons();
-                    _applicationContext.FranchiseSeasons.Clear();
+                    _applicationContext.LeagueSeasons.Clear();
                     foreach (var season in seasons)
                     {
-                        _applicationContext.FranchiseSeasons.Add(season);
+                        _applicationContext.LeagueSeasons.Add(season);
                     }
     
                     var mostRecentSeason = seasons.MaxBy(x => x.SeasonNum);
 
                     Debug.Assert(mostRecentSeason != null, nameof(mostRecentSeason) + " != null");
                     Log.Information("Most recent franchise season: {SeasonNum}", mostRecentSeason.SeasonNum);
-                    _applicationContext.MostRecentFranchiseSeason = mostRecentSeason;
-                    _applicationContext.FranchiseSeasonsLoading = false;
+                    _applicationContext.MostRecentLeagueSeason = mostRecentSeason;
+                    _applicationContext.LeagueSeasonsLoading = false;
                     
                     Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Arrow);
                 });

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseCareer.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseCareer.cs
@@ -19,7 +19,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -87,7 +87,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseSeasons.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
@@ -20,18 +19,18 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
 
-        List<FranchiseSeason> seasons = new();
+        List<FranchiseSeason> seasons = [];
         while (reader.Read())
         {
             var seasonId = int.Parse(reader["seasonId"].ToString()!);
             var seasonNum = int.Parse(reader["seasonNum"].ToString()!);
 
-            var seasonBytes = reader["leagueGUID"] as byte[] ?? Array.Empty<byte>();
+            var seasonBytes = reader["leagueGUID"] as byte[] ?? [];
             var seasonGuid = seasonBytes.ToGuid();
 
             var season = new FranchiseSeason(seasonId, seasonNum, seasonGuid);
@@ -53,7 +52,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -78,7 +77,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseTeams.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseTeams.cs
@@ -35,8 +35,16 @@ public partial class DataService
             standing.RunsFor = int.Parse(reader["runsFor"].ToString()!);
             standing.RunsAgainst = int.Parse(reader["runsAgainst"].ToString()!);
             standing.RunDifferential = int.Parse(reader["runDifferential"].ToString()!);
-            standing.WinPercentage = double.Parse(reader["winPct"].ToString()!);
-            standing.GamesBack = double.Parse(reader["gamesBack"].ToString()!);
+
+            var winPercentageRaw = reader["winPct"].ToString()!;
+            standing.WinPercentage = string.IsNullOrEmpty(winPercentageRaw) 
+                ? 0
+                : double.Parse(winPercentageRaw);
+
+            var gamesBackRaw = reader["gamesBack"].ToString()!;
+            standing.GamesBack = string.IsNullOrEmpty(gamesBackRaw) 
+                ? 0
+                : double.Parse(gamesBackRaw);
 
             yield return standing;
         }

--- a/SMB3Explorer/Services/DataService/DataServiceFranchiseTeams.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchiseTeams.cs
@@ -15,7 +15,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -50,7 +50,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();

--- a/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using SMB3Explorer.Models.Internal;
 using SMB3Explorer.Utils;
@@ -23,16 +24,17 @@ public partial class DataService
             var franchiseBytes = reader["franchiseId"] as byte[];
             var franchiseId = franchiseBytes?.ToGuid();
 
-            var isElimination = (bool)reader["elimination"];
+            var isEliminationRaw = reader["elimination"] is DBNull ? null : (long?)reader["elimination"];
 
             var franchise = new FranchiseSelection
             {
                 LeagueId = leagueId,
-                Mode = (franchiseId, isElimination) switch
+                Mode = (franchiseId, isEliminationRaw) switch
                 {
-                    (null, true) => LeagueMode.Elimination,
-                    (null, false) => LeagueMode.Season,
-                    _ => LeagueMode.Franchise
+                    (not null, _) => LeagueMode.Franchise,
+                    (null, 1) => LeagueMode.Elimination,
+                    (null, 0) => LeagueMode.Season,
+                    _ => LeagueMode.None
                 },
                 LeagueName = reader["leagueName"].ToString()!,
                 LeagueType = reader["leagueTypeName"].ToString()!,

--- a/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
@@ -20,16 +20,23 @@ public partial class DataService
             var leagueBytes = reader["leagueId"] as byte[] ?? [];
             var leagueId = leagueBytes.ToGuid();
 
-            var franchiseBytes = reader["franchiseId"] as byte[] ?? [];
-            var franchiseId = franchiseBytes.ToGuid();
+            var franchiseBytes = reader["franchiseId"] as byte[];
+            var franchiseId = franchiseBytes?.ToGuid();
+
+            var isElimination = (bool)reader["elimination"];
 
             var franchise = new FranchiseSelection
             {
                 LeagueId = leagueId,
-                FranchiseId = franchiseId,
+                Mode = (franchiseId, isElimination) switch
+                {
+                    (null, true) => LeagueMode.Elimination,
+                    (null, false) => LeagueMode.Season,
+                    _ => LeagueMode.Franchise
+                },
                 LeagueName = reader["leagueName"].ToString()!,
                 LeagueType = reader["leagueTypeName"].ToString()!,
-                PlayerTeamName = reader["playerTeamName"].ToString()!,
+                PlayerTeamName = reader["playerTeamName"].ToString(),
                 NumSeasons = int.Parse(reader["numSeasons"].ToString()!)
             };
             franchises.Add(franchise);

--- a/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using SMB3Explorer.Models.Internal;
 using SMB3Explorer.Utils;
@@ -15,13 +14,13 @@ public partial class DataService
         command.CommandText = commandText;
         var reader = await command.ExecuteReaderAsync();
 
-        List<FranchiseSelection> franchises = new();
+        List<FranchiseSelection> franchises = [];
         while (reader.Read())
         {
-            var leagueBytes = reader["leagueId"] as byte[] ?? Array.Empty<byte>();
+            var leagueBytes = reader["leagueId"] as byte[] ?? [];
             var leagueId = leagueBytes.ToGuid();
 
-            var franchiseBytes = reader["franchiseId"] as byte[] ?? Array.Empty<byte>();
+            var franchiseBytes = reader["franchiseId"] as byte[] ?? [];
             var franchiseId = franchiseBytes.ToGuid();
 
             var franchise = new FranchiseSelection

--- a/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
@@ -8,14 +8,14 @@ namespace SMB3Explorer.Services.DataService;
 
 public partial class DataService
 {
-    public async Task<List<FranchiseSelection>> GetFranchises()
+    public async Task<List<LeagueSelection>> GetLeagues()
     {
         var command = Connection!.CreateCommand();
         var commandText = SqlRunner.GetSqlCommand(SqlFile.Franchises);
         command.CommandText = commandText;
         var reader = await command.ExecuteReaderAsync();
 
-        List<FranchiseSelection> franchises = [];
+        List<LeagueSelection> franchises = [];
         while (reader.Read())
         {
             var leagueBytes = reader["leagueId"] as byte[] ?? [];
@@ -26,7 +26,7 @@ public partial class DataService
 
             var isEliminationRaw = reader["elimination"] is DBNull ? null : (long?)reader["elimination"];
 
-            var franchise = new FranchiseSelection
+            var franchise = new LeagueSelection
             {
                 LeagueId = leagueId,
                 Mode = (franchiseId, isEliminationRaw) switch

--- a/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceFranchises.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using SMB3Explorer.Models.Internal;
 using SMB3Explorer.Utils;
@@ -24,18 +23,12 @@ public partial class DataService
             var franchiseBytes = reader["franchiseId"] as byte[];
             var franchiseId = franchiseBytes?.ToGuid();
 
-            var isEliminationRaw = reader["elimination"] is DBNull ? null : (long?)reader["elimination"];
+            var isEliminationRaw = reader.IsDBNull(8) ? null : (bool?)reader.GetBoolean(8);
 
             var franchise = new LeagueSelection
             {
                 LeagueId = leagueId,
-                Mode = (franchiseId, isEliminationRaw) switch
-                {
-                    (not null, _) => LeagueMode.Franchise,
-                    (null, 1) => LeagueMode.Elimination,
-                    (null, 0) => LeagueMode.Season,
-                    _ => LeagueMode.None
-                },
+                Mode = LeagueModeExtensions.Parse(franchiseId is not null, isEliminationRaw),
                 LeagueName = reader["leagueName"].ToString()!,
                 LeagueType = reader["leagueTypeName"].ToString()!,
                 PlayerTeamName = reader["playerTeamName"].ToString(),

--- a/SMB3Explorer/Services/DataService/DataServiceInit.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceInit.cs
@@ -133,8 +133,16 @@ public partial class DataService
             var leagueName = reader2.GetString(0);
             var playerTeamName = reader2.IsDBNull(1) ? null : reader2.GetString(1);
             int? numSeasons = reader2.IsDBNull(2) ? null : reader2.GetInt32(2);
+            
+            var isElimination = reader2.IsDBNull(3) ? null : (bool?)reader2.GetBoolean(3);
 
-            var league = new Smb4LeagueSelection(leagueName, smb4LeagueId, playerTeamName, numSeasons);
+            var franchiseBytes = reader2["franchiseId"] as byte[];
+            var franchiseId = franchiseBytes?.ToGuid();
+
+            var league = new Smb4LeagueSelection(leagueName, smb4LeagueId, playerTeamName, numSeasons)
+            {
+                Mode = LeagueModeExtensions.Parse(franchiseId is not null, isElimination)
+            };
             leagues.Add(league);
         }
 

--- a/SMB3Explorer/Services/DataService/DataServiceInit.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceInit.cs
@@ -110,7 +110,7 @@ public partial class DataService
             return new List<Smb4LeagueSelection>();
         }
 
-        List<Smb4LeagueSelection> leagues = new();
+        List<Smb4LeagueSelection> leagues = [];
         var command2 = Connection.CreateCommand();
         commandText = SqlRunner.GetSqlCommand(SqlFile.GetLeaguesForSmb4SaveGame);
         command2.CommandText = commandText;

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
+using Serilog;
 using SMB3Explorer.Enums;
 using SMB3Explorer.Models.Exports;
 using SMB3Explorer.Utils;
@@ -218,11 +219,39 @@ public partial class DataService
                 seasonPlayer.Traits = _applicationContext.SelectedGame switch
                 {
                     SelectedGame.Smb3 => traits
-                        .Select(x => PlayerTrait.Smb3TraitMap[x])
+                        .Select(x =>
+                        {
+                            var ok = PlayerTrait.Smb3TraitMap.TryGetValue(x, out var trait);
+                            if (!ok)
+                            {
+                                Log.Warning(
+                                    "Trait {Trait} not found in database. This may be due to a missing or incorrect trait",
+                                    x);
+                                return (Trait?)null;
+                            }
+
+                            return trait;
+                        })
+                        .Where(x => x is not null)
+                        .Cast<Trait>()
                         .Distinct()
                         .ToArray(),
                     SelectedGame.Smb4 => traits
-                        .Select(x => PlayerTrait.Smb4TraitMap[x])
+                        .Select(x =>
+                        {
+                            var ok =  PlayerTrait.Smb4TraitMap.TryGetValue(x, out var trait);
+                            if (!ok)
+                            {
+                                Log.Warning(
+                                    "Trait {Trait} not found in database. This may be due to a missing or incorrect trait",
+                                    x);
+                                return (Trait?)null;
+                            }
+
+                            return trait;
+                        })
+                        .Where(x => x is not null)
+                        .Cast<Trait>()
                         .Distinct()
                         .ToArray(),
                     _ => throw new ArgumentException()
@@ -243,7 +272,19 @@ public partial class DataService
                     var pitches = JsonSerializer.Deserialize<DatabaseIntOption[]>(pitchesSerialized) ?? [];
 
                     seasonPlayer.Pitches = pitches
-                        .Select(x => PitchTypes.Pitches[x])
+                        .Select(x =>
+                        {
+                            var ok = PitchTypes.Pitches.TryGetValue(x, out var pitchType);
+                            if (!ok)
+                            {
+                                Log.Warning(
+                                    "Pitch type {PitchType} not found in database. This may be due to a missing or incorrect pitch type",
+                                    x);
+                                return null;
+                            }
+
+                            return pitchType;
+                        })
                         .Where(x => x is not null)
                         .Cast<PitchType>()
                         .Distinct()

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -32,7 +32,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         command.Parameters.Add(new SqliteParameter("@leagueOps", SqliteType.Real)
@@ -105,7 +105,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         command.Parameters.Add(new SqliteParameter("@leagueEra", SqliteType.Real)
@@ -178,7 +178,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -264,7 +264,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -313,7 +313,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -350,7 +350,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -392,7 +392,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -418,7 +418,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();
@@ -445,7 +445,7 @@ public partial class DataService
 
         command.Parameters.Add(new SqliteParameter("@leagueId", SqliteType.Blob)
         {
-            Value = _applicationContext.SelectedFranchise!.LeagueId.ToBlob()
+            Value = _applicationContext.SelectedLeague!.LeagueId.ToBlob()
         });
 
         var reader = await command.ExecuteReaderAsync();

--- a/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
+++ b/SMB3Explorer/Services/DataService/DataServiceMostRecentSeason.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
-using Newtonsoft.Json;
 using SMB3Explorer.Enums;
 using SMB3Explorer.Models.Exports;
 using SMB3Explorer.Utils;
@@ -213,8 +213,7 @@ public partial class DataService
             if (!string.IsNullOrEmpty(traitsSerialized))
             {
                 var traits =
-                    JsonConvert.DeserializeObject<PlayerTrait.DatabaseTraitSubtypePair[]>(traitsSerialized) ??
-                    Array.Empty<PlayerTrait.DatabaseTraitSubtypePair>();
+                    JsonSerializer.Deserialize<PlayerTrait.DatabaseTraitSubtypePair[]>(traitsSerialized) ?? [];
 
                 seasonPlayer.Traits = _applicationContext.SelectedGame switch
                 {
@@ -241,8 +240,7 @@ public partial class DataService
                 var pitchesSerialized = reader.IsDBNull(24) ? null : reader.GetString(24);
                 if (!string.IsNullOrEmpty(pitchesSerialized))
                 {
-                    var pitches = JsonConvert.DeserializeObject<DatabaseIntOption[]>(pitchesSerialized) ??
-                                  Array.Empty<DatabaseIntOption>();
+                    var pitches = JsonSerializer.Deserialize<DatabaseIntOption[]>(pitchesSerialized) ?? [];
 
                     seasonPlayer.Pitches = pitches
                         .Select(x => PitchTypes.Pitches[x])

--- a/SMB3Explorer/Services/DataService/IDataService.cs
+++ b/SMB3Explorer/Services/DataService/IDataService.cs
@@ -18,8 +18,7 @@ public interface IDataService
     Task<OneOf<List<Smb4LeagueSelection>, Error<string>>> EstablishDbConnection(string filePath,
         bool isCompressedSaveGame = true);
 
-    Task<List<FranchiseSelection>> GetFranchises();
-    Task<List<FranchiseSeason>> GetFranchiseSeasons();
+    Task<List<LeagueSelection>> GetLeagues();
 
     event EventHandler<EventArgs> ConnectionChanged;
 

--- a/SMB3Explorer/Services/SystemIoWrapper/ISystemIoWrapper.cs
+++ b/SMB3Explorer/Services/SystemIoWrapper/ISystemIoWrapper.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using System.Windows;
-using Ionic.Zlib;
 using Microsoft.Win32;
 using SMB3Explorer.Services.CsvWriterWrapper;
 
@@ -26,7 +26,7 @@ public interface ISystemIoWrapper
     Stream? FileOpenRead(string path);
     long FileGetSize(string path);
     
-    ZlibStream GetZlibDecompressionStream(Stream stream);
+    DeflateStream GetZlibDecompressionStream(Stream stream);
     
     bool DirectoryExists(string path);
     void DirectoryCreate(string path);

--- a/SMB3Explorer/Services/SystemIoWrapper/ISystemIoWrapper.cs
+++ b/SMB3Explorer/Services/SystemIoWrapper/ISystemIoWrapper.cs
@@ -26,7 +26,7 @@ public interface ISystemIoWrapper
     Stream? FileOpenRead(string path);
     long FileGetSize(string path);
     
-    DeflateStream GetZlibDecompressionStream(Stream stream);
+    ZLibStream GetZlibDecompressionStream(Stream stream);
     
     bool DirectoryExists(string path);
     void DirectoryCreate(string path);

--- a/SMB3Explorer/Services/SystemIoWrapper/SystemIoWrapper.cs
+++ b/SMB3Explorer/Services/SystemIoWrapper/SystemIoWrapper.cs
@@ -81,9 +81,9 @@ public class SystemIoWrapper : ISystemIoWrapper
         return File.OpenRead(path);
     }
 
-    public DeflateStream GetZlibDecompressionStream(Stream stream)
+    public ZLibStream GetZlibDecompressionStream(Stream stream)
     {
-        return new DeflateStream(stream, CompressionMode.Decompress);
+        return new ZLibStream(stream, CompressionMode.Decompress);
     }
 
     public long FileGetSize(string path)

--- a/SMB3Explorer/Services/SystemIoWrapper/SystemIoWrapper.cs
+++ b/SMB3Explorer/Services/SystemIoWrapper/SystemIoWrapper.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using System.Windows;
-using Ionic.Zlib;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
 using Serilog;
@@ -81,9 +81,9 @@ public class SystemIoWrapper : ISystemIoWrapper
         return File.OpenRead(path);
     }
 
-    public ZlibStream GetZlibDecompressionStream(Stream stream)
+    public DeflateStream GetZlibDecompressionStream(Stream stream)
     {
-        return new ZlibStream(stream, CompressionMode.Decompress);
+        return new DeflateStream(stream, CompressionMode.Decompress);
     }
 
     public long FileGetSize(string path)

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -24,7 +23,7 @@ public partial class HomeViewModel : ViewModelBase
     private readonly INavigationService _navigationService;
     private readonly ISystemIoWrapper _systemIoWrapper;
 
-    private ObservableCollection<FranchiseSelection> _franchises = new();
+    private ObservableCollection<FranchiseSelection> _franchises = [];
     private bool _interactionEnabled;
     private FranchiseSelection? _selectedFranchise;
     private bool _atLeastOneFranchiseSeasonExists;
@@ -473,7 +472,7 @@ public partial class HomeViewModel : ViewModelBase
                     return;
                 }
 
-                if (task.Result.Any())
+                if (task.Result.Count != 0)
                 {
                     Log.Debug("{Count} Franchises found", task.Result.Count);
                     Franchises = new ObservableCollection<FranchiseSelection>(task.Result);

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -23,10 +24,10 @@ public partial class HomeViewModel : ViewModelBase
     private readonly INavigationService _navigationService;
     private readonly ISystemIoWrapper _systemIoWrapper;
 
-    private ObservableCollection<FranchiseSelection> _franchises = [];
+    private ObservableCollection<LeagueSelection> _leagues = [];
     private bool _interactionEnabled;
-    private FranchiseSelection? _selectedFranchise;
-    private bool _atLeastOneFranchiseSeasonExists;
+    private LeagueSelection? _selectedLeague;
+    private bool _atLeastOneLeagueSeasonExists;
 
     public HomeViewModel(INavigationService navigationService, IDataService dataService,
         IApplicationContext applicationContext, ISystemIoWrapper systemIoWrapper)
@@ -43,24 +44,24 @@ public partial class HomeViewModel : ViewModelBase
         GetFranchises();
     }
 
-    public FranchiseSelection? SelectedFranchise
+    public LeagueSelection? SelectedLeague
     {
-        get => _selectedFranchise;
+        get => _selectedLeague;
         set
         {
-            SetField(ref _selectedFranchise, value);
-            _applicationContext.SelectedFranchise = value;
+            SetField(ref _selectedLeague, value);
+            _applicationContext.SelectedLeague = value;
             
             var leagueName = value?.LeagueNameSafe ?? "None";
             Log.Information("Set selected league to {LeagueNameSafe}", leagueName);
-            OnPropertyChanged(nameof(FranchiseSelected));
+            OnPropertyChanged(nameof(LeagueSelected));
         }
     }
 
-    public ObservableCollection<FranchiseSelection> Franchises
+    public ObservableCollection<LeagueSelection> Leagues
     {
-        get => _franchises;
-        private set => SetField(ref _franchises, value);
+        get => _leagues;
+        private set => SetField(ref _leagues, value);
     }
 
     public bool InteractionEnabled
@@ -69,27 +70,27 @@ public partial class HomeViewModel : ViewModelBase
         set => SetField(ref _interactionEnabled, value);
     }
 
-    public Visibility NoFranchiseSeasonsVisibility
+    public Visibility NoLeagueSeasonsVisibility
     {
         get
         {
-            if (!FranchiseSelected) return Visibility.Collapsed;
+            if (!LeagueSelected) return Visibility.Collapsed;
 
-            if (AtLeastOneFranchiseSeasonExists) return Visibility.Collapsed;
+            if (AtLeastOneLeagueSeasonExists) return Visibility.Collapsed;
 
             return Visibility.Visible;
         }
     }
 
-    private bool FranchiseSelected => SelectedFranchise is not null;
+    private bool LeagueSelected => SelectedLeague is not null;
 
-    private bool AtLeastOneFranchiseSeasonExists
+    private bool AtLeastOneLeagueSeasonExists
     {
-        get => _atLeastOneFranchiseSeasonExists;
+        get => _atLeastOneLeagueSeasonExists;
         set
         {
-            _atLeastOneFranchiseSeasonExists = value;
-            OnPropertyChanged(nameof(NoFranchiseSeasonsVisibility));
+            _atLeastOneLeagueSeasonExists = value;
+            OnPropertyChanged(nameof(NoLeagueSeasonsVisibility));
         }
     }
 
@@ -97,9 +98,9 @@ public partial class HomeViewModel : ViewModelBase
     {
         switch (e.PropertyName)
         {
-            case nameof(ApplicationContext.MostRecentFranchiseSeason):
+            case nameof(ApplicationContext.MostRecentLeagueSeason):
             {
-                AtLeastOneFranchiseSeasonExists = _applicationContext.MostRecentFranchiseSeason is not null;
+                AtLeastOneLeagueSeasonExists = _applicationContext.MostRecentLeagueSeason is not null;
 
                 Application.Current.Dispatcher.Invoke(() =>
                 {
@@ -154,7 +155,7 @@ public partial class HomeViewModel : ViewModelBase
         var playersEnumerable = _dataService.GetFranchiseCareerBattingStatistics(isRegularSeason);
 
         var battingType = isRegularSeason ? "regular_season" : "playoffs";
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_career_batting_{battingType}_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_career_batting_{battingType}_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -182,7 +183,7 @@ public partial class HomeViewModel : ViewModelBase
         var playersEnumerable = _dataService.GetFranchiseCareerPitchingStatistics(isRegularSeason);
 
         var pitchingType = isRegularSeason ? "regular_season" : "playoffs";
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_career_pitching_{pitchingType}_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_career_pitching_{pitchingType}_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -210,7 +211,7 @@ public partial class HomeViewModel : ViewModelBase
         var playersEnumerable = _dataService.GetFranchiseSeasonBattingStatistics(isRegularSeason);
 
         var battingType = isRegularSeason ? "regular_season" : "playoffs";
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_season_batting_{battingType}_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_season_batting_{battingType}_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -238,7 +239,7 @@ public partial class HomeViewModel : ViewModelBase
         var playersEnumerable = _dataService.GetFranchiseSeasonPitchingStatistics(isRegularSeason);
 
         var pitchingType = isRegularSeason ? "regular_season" : "playoffs";
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_season_pitching_{pitchingType}_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_season_pitching_{pitchingType}_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -254,7 +255,7 @@ public partial class HomeViewModel : ViewModelBase
 
         var teamsEnumerable = _dataService.GetFranchiseSeasonStandings();
 
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_season_standings_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_season_standings_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, teamsEnumerable, fileName);
@@ -270,7 +271,7 @@ public partial class HomeViewModel : ViewModelBase
 
         var teamsEnumerable = _dataService.GetFranchisePlayoffStandings();
 
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_playoff_standings_" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_playoff_standings_" +
                        $"{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, teamsEnumerable, fileName);
@@ -322,8 +323,8 @@ public partial class HomeViewModel : ViewModelBase
             _ => throw new ArgumentOutOfRangeException(nameof(filter), filter, null)
         };
 
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_top_batting_{exportType}_" +
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_top_batting_{exportType}_" +
                        $"{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -374,8 +375,8 @@ public partial class HomeViewModel : ViewModelBase
             _ => throw new ArgumentOutOfRangeException(nameof(filter), filter, null)
         };
 
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_top_pitching_{exportType}_" +
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_top_pitching_{exportType}_" +
                        $"{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
 
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -390,8 +391,8 @@ public partial class HomeViewModel : ViewModelBase
 
         var playersEnumerable = _dataService.GetMostRecentSeasonPlayers();
         
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_players" +
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_players" +
                        $"_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
         
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playersEnumerable, fileName);
@@ -406,8 +407,8 @@ public partial class HomeViewModel : ViewModelBase
         
         var teamsEnumerable = _dataService.GetMostRecentSeasonTeams();
         
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_teams" +
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_teams" +
                        $"_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
         
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, teamsEnumerable, fileName);
@@ -422,8 +423,8 @@ public partial class HomeViewModel : ViewModelBase
         
         var scheduleEnumerable = _dataService.GetMostRecentSeasonSchedule();
         
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_schedule" +
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_schedule" +
                        $"_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
         
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, scheduleEnumerable, fileName);
@@ -445,9 +446,9 @@ public partial class HomeViewModel : ViewModelBase
         }
 
         var playoffScheduleEnumerable = _dataService.GetMostRecentSeasonPlayoffSchedule();
-        var mostRecentSeason = _applicationContext.MostRecentFranchiseSeason;
+        var mostRecentSeason = _applicationContext.MostRecentLeagueSeason;
         
-        var fileName = $"{_applicationContext.SelectedFranchise!.LeagueNameSafe}_schedule" +
+        var fileName = $"{_applicationContext.SelectedLeague!.LeagueNameSafe}_schedule" +
                        $"_playoffs_season_{mostRecentSeason!.SeasonNum}_{DateTime.Now:yyyyMMddHHmmssfff}.csv";
         
         var (filePath, _) = await CsvUtils.ExportCsv(_systemIoWrapper, playoffScheduleEnumerable, fileName);
@@ -457,31 +458,40 @@ public partial class HomeViewModel : ViewModelBase
 
     private bool CanExport()
     {
-        return FranchiseSelected && AtLeastOneFranchiseSeasonExists;
+        return LeagueSelected && AtLeastOneLeagueSeasonExists;
     }
 
     private void GetFranchises()
     {
-        _dataService.GetFranchises()
+        _dataService.GetLeagues()
             .ContinueWith(async task =>
             {
                 if (task.Exception != null)
                 {
-                    DefaultExceptionHandler.HandleException(_systemIoWrapper, "Failed to get franchises.",
+                    DefaultExceptionHandler.HandleException(_systemIoWrapper, "Failed to get leagues.",
                         task.Exception);
                     return;
                 }
 
-                if (task.Result.Count != 0)
+                var rawResults = task.Result;
+
+                Log.Debug("Filtering out ineligible leagues (lacking at least one game played), found {Count} total leagues",
+                    rawResults.Count);
+                var filteredResults = rawResults
+                    .Where(x => x.Mode is not LeagueMode.None)
+                    .ToList();
+                Log.Debug("Filtered out ineligible leagues, left with {Count} eligible leagues", filteredResults.Count);
+
+                if (filteredResults.Count != 0)
                 {
-                    Log.Debug("{Count} Franchises found", task.Result.Count);
-                    Franchises = new ObservableCollection<FranchiseSelection>(task.Result);
+                    Log.Debug("{Count} Franchises found", filteredResults.Count);
+                    Leagues = new ObservableCollection<LeagueSelection>(filteredResults);
                     InteractionEnabled = true;
                 }
                 else
                 {
-                    Log.Debug("No franchises found, navigating to landing page");
-                    MessageBox.Show("No franchises found. Please select a different save file.");
+                    Log.Debug("No leagues found, navigating to landing page");
+                    MessageBox.Show("No leagues found. Please select a different save file.");
                     await _dataService.Disconnect();
                     _navigationService.NavigateTo<LandingViewModel>();
                 }

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -135,13 +135,13 @@ public partial class HomeViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseCareerBattingStatistics()
     {
         await HandleFranchiseCareerBattingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseCareerPlayoffBattingStatistics()
     {
         await HandleFranchiseCareerBattingExport(false);
@@ -163,13 +163,13 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseCareerPitchingStatistics()
     {
         await HandleFranchiseCareerPitchingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseCareerPlayoffPitchingStatistics()
     {
         await HandleFranchiseCareerPitchingExport(false);
@@ -191,13 +191,13 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportFranchiseSeasonBattingStatistics()
     {
         await HandleFranchiseSeasonBattingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportFranchiseSeasonPlayoffBattingStatistics()
     {
         await HandleFranchiseSeasonBattingExport(false);
@@ -219,13 +219,13 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportFranchiseSeasonPitchingStatistics()
     {
         await HandleFranchiseSeasonPitchingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportFranchiseSeasonPlayoffPitchingStatistics()
     {
         await HandleFranchiseSeasonPitchingExport(false);
@@ -247,7 +247,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportFranchiseTeamSeasonStandings()
     {
         Log.Information("Exporting franchise season standings...");
@@ -263,7 +263,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportFranchiseTeamPlayoffStandings()
     {
         Log.Information("Exporting franchise playoff standings...");
@@ -280,19 +280,19 @@ public partial class HomeViewModel : ViewModelBase
     }
 
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportTopPerformersBatting()
     {
         await HandleTopPerformersBattingExport(MostRecentSeasonFilter.RegularSeason);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportTopRookiesBatting()
     {
         await HandleTopPerformersBattingExport(MostRecentSeasonFilter.Rookies);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportTopPerformersBattingPlayoffs()
     {
         await HandleTopPerformersBattingExport(MostRecentSeasonFilter.Playoffs);
@@ -332,19 +332,19 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportTopPerformersPitching()
     {
         await HandleTopPerformersPitchingExport(MostRecentSeasonFilter.RegularSeason);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportTopRookiesPitching()
     {
         await HandleTopPerformersPitchingExport(MostRecentSeasonFilter.Rookies);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportTopPerformersPitchingPlayoffs()
     {
         await HandleTopPerformersPitchingExport(MostRecentSeasonFilter.Playoffs);
@@ -384,7 +384,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportMostRecentSeasonPlayers()
     {
         Mouse.OverrideCursor = Cursors.Wait;
@@ -400,7 +400,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportMostRecentSeasonTeams()
     {
         Mouse.OverrideCursor = Cursors.Wait;
@@ -416,7 +416,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportSeason))]
     private async Task ExportMostRecentSeasonSchedule()
     {
         Mouse.OverrideCursor = Cursors.Wait;
@@ -432,7 +432,7 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExport))]
+    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
     private async Task ExportMostRecentSeasonPlayoffSchedule()
     {
         Mouse.OverrideCursor = Cursors.Wait;
@@ -456,9 +456,61 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    private bool CanExport()
+    /// <summary>
+    /// Applies to exports that have a season context (franchise and season)
+    /// </summary>
+    /// <returns></returns>
+    private bool CanExportSeason()
     {
-        return LeagueSelected && AtLeastOneLeagueSeasonExists;
+        if (!LeagueSelected || !AtLeastOneLeagueSeasonExists)
+        {
+            return false;
+        }
+
+        return _selectedLeague!.Mode switch
+        {
+            LeagueMode.Franchise => true,
+            LeagueMode.Season => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Applies to exports that are contain a playoff format (franchise, season, and elimination)
+    /// </summary>
+    /// <returns></returns>
+    private bool CanExportPlayoff()
+    {
+        if (!LeagueSelected || !AtLeastOneLeagueSeasonExists)
+        {
+            return false;
+        }
+
+        return _selectedLeague!.Mode switch
+        {
+            LeagueMode.Franchise => true,
+            LeagueMode.Season => true,
+            LeagueMode.Elimination => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Applies to exports that are historical in nature (franchise only)
+    /// </summary>
+    /// <returns></returns>
+    private bool CanExportHistorical()
+    {
+        if (!LeagueSelected || !AtLeastOneLeagueSeasonExists)
+        {
+            return false;
+        }
+
+        return _selectedLeague!.Mode switch
+        {
+            LeagueMode.Franchise => true,
+            _ => false
+        };
     }
 
     private void GetFranchises()

--- a/SMB3Explorer/ViewModels/HomeViewModel.cs
+++ b/SMB3Explorer/ViewModels/HomeViewModel.cs
@@ -191,13 +191,13 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExportSeason))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseSeasonBattingStatistics()
     {
         await HandleFranchiseSeasonBattingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseSeasonPlayoffBattingStatistics()
     {
         await HandleFranchiseSeasonBattingExport(false);
@@ -219,13 +219,13 @@ public partial class HomeViewModel : ViewModelBase
         HandleExportSuccess(filePath);
     }
 
-    [RelayCommand(CanExecute = nameof(CanExportSeason))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseSeasonPitchingStatistics()
     {
         await HandleFranchiseSeasonPitchingExport();
     }
 
-    [RelayCommand(CanExecute = nameof(CanExportPlayoff))]
+    [RelayCommand(CanExecute = nameof(CanExportHistorical))]
     private async Task ExportFranchiseSeasonPlayoffPitchingStatistics()
     {
         await HandleFranchiseSeasonPitchingExport(false);

--- a/SMB3Explorer/ViewModels/LandingViewModel.cs
+++ b/SMB3Explorer/ViewModels/LandingViewModel.cs
@@ -281,7 +281,7 @@ public partial class LandingViewModel : ViewModelBase
                     .Where(x => !existingLeagues.Contains(x))
                     .ToList();
 
-                if (newLeagues.Any())
+                if (newLeagues.Count != 0)
                 {
                     var now = DateTime.Now;
                     configOptions.Leagues.AddRange(newLeagues

--- a/SMB3Explorer/ViewModels/LandingViewModel.cs
+++ b/SMB3Explorer/ViewModels/LandingViewModel.cs
@@ -48,7 +48,7 @@ public partial class LandingViewModel : ViewModelBase
         {
             Log.Error("Could not retrieve config options for previously selected leagues: {Error}", error);
             MessageBox.Show($"Could not retrieve config options for previously selected leagues: {error.Value}");
-            Smb4LeagueSelections = new List<Smb4LeagueSelection>();
+            Smb4LeagueSelections = [];
         }
 
         Smb4LeagueSelections = configOptions.Leagues
@@ -56,7 +56,8 @@ public partial class LandingViewModel : ViewModelBase
             {
                 NumTimesAccessed = x.NumTimesAccessed,
                 FirstAccessed = x.FirstAccessed,
-                LastAccessed = x.LastAccessed
+                LastAccessed = x.LastAccessed,
+                Mode = x.Mode
             })
             .OrderByDescending(x => x.NumTimesAccessed)
             .ToList();
@@ -128,7 +129,8 @@ public partial class LandingViewModel : ViewModelBase
             {
                 NumTimesAccessed = x.NumTimesAccessed,
                 FirstAccessed = x.FirstAccessed,
-                LastAccessed = x.LastAccessed
+                LastAccessed = x.LastAccessed,
+                Mode = x.Mode
             })
             .OrderByDescending(x => x.NumTimesAccessed)
             .ToList();
@@ -273,7 +275,8 @@ public partial class LandingViewModel : ViewModelBase
                     {
                         NumTimesAccessed = x.NumTimesAccessed,
                         FirstAccessed = x.FirstAccessed,
-                        LastAccessed = x.LastAccessed
+                        LastAccessed = x.LastAccessed,
+                        Mode = x.Mode
                     })
                     .ToList();
 
@@ -288,6 +291,7 @@ public partial class LandingViewModel : ViewModelBase
                         .Select(x => new League
                         {
                             Id = x.SaveGameLeagueId,
+                            Mode = x.Mode,
                             Name = x.LeagueName,
                             PlayerTeam = x.PlayerTeam,
                             NumSeasons = x.NumSeasons,
@@ -339,7 +343,8 @@ public partial class LandingViewModel : ViewModelBase
                             NumSeasons = existingLeagueFromQuery.NumSeasons,
                             NumTimesAccessed = existingLeagueCached.NumTimesAccessed,
                             FirstAccessed = existingLeagueCached.FirstAccessed,
-                            LastAccessed = existingLeagueCached.LastAccessed
+                            LastAccessed = existingLeagueCached.LastAccessed,
+                            Mode = existingLeagueCached.Mode ?? existingLeagueFromQuery.Mode
                         });
 
                         _applicationConfig.SaveConfigOptions(configOptions);

--- a/SMB3Explorer/Views/HomeView.xaml
+++ b/SMB3Explorer/Views/HomeView.xaml
@@ -30,11 +30,11 @@
                         HorizontalAlignment="Stretch"
                         Height="25"
                         DisplayMemberPath="DisplayText"
-                        ItemsSource="{Binding Franchises}"
-                        SelectedItem="{Binding SelectedFranchise}" />
+                        ItemsSource="{Binding Leagues}"
+                        SelectedItem="{Binding SelectedLeague}" />
 
                     <Label
-                        Visibility="{Binding NoFranchiseSeasonsVisibility}"
+                        Visibility="{Binding NoLeagueSeasonsVisibility}"
                         Content="No seasons exist for this franchise"
                         Foreground="Red"
                         FontWeight="Bold" />

--- a/SMB3ExplorerTests/DataServiceTests/DataServiceInitTests.cs
+++ b/SMB3ExplorerTests/DataServiceTests/DataServiceInitTests.cs
@@ -1,4 +1,4 @@
-﻿using Ionic.Zlib;
+﻿using System.IO.Compression;
 using Moq;
 using SMB3Explorer.Services.ApplicationContext;
 using SMB3Explorer.Services.DataService;
@@ -22,7 +22,7 @@ public class DataServiceInitTests
             .Returns(mockFileStream.Object);
 
         mockSystemIoWrapper.Setup(x => x.GetZlibDecompressionStream(It.IsAny<Stream>()))
-            .Returns(new ZlibStream(mockFileStream.Object, CompressionMode.Decompress));
+            .Returns(new DeflateStream(mockFileStream.Object, CompressionMode.Decompress));
 
         mockSystemIoWrapper.Setup(x => x.FileCreateStream(It.IsAny<string>()))
             .Returns(mockFileStream.Object);

--- a/SMB3ExplorerTests/DataServiceTests/DataServiceInitTests.cs
+++ b/SMB3ExplorerTests/DataServiceTests/DataServiceInitTests.cs
@@ -22,7 +22,7 @@ public class DataServiceInitTests
             .Returns(mockFileStream.Object);
 
         mockSystemIoWrapper.Setup(x => x.GetZlibDecompressionStream(It.IsAny<Stream>()))
-            .Returns(new DeflateStream(mockFileStream.Object, CompressionMode.Decompress));
+            .Returns(new ZLibStream(mockFileStream.Object, CompressionMode.Decompress));
 
         mockSystemIoWrapper.Setup(x => x.FileCreateStream(It.IsAny<string>()))
             .Returns(mockFileStream.Object);
@@ -42,7 +42,7 @@ public class DataServiceInitTests
         }
         else
         {
-            Assert.True(false, "Expected a successful result.");
+            Assert.Fail("Expected a successful result.");
         }
     }
 
@@ -68,7 +68,7 @@ public class DataServiceInitTests
         }
         else
         {
-            Assert.True(false, "Expected an error result.");
+            Assert.Fail("Expected an error result.");
         }
     }
 }

--- a/SMB3ExplorerTests/SMB3ExplorerTests.csproj
+++ b/SMB3ExplorerTests/SMB3ExplorerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Adds support for the following:
Franchise (existing), Season, and Elimination mode exports (new)

Supported exports:
- Team standings
    - [x] Team standings for regular seasons
    - [x] Team playoff standings
- Current season
    - [x] Top batters
    - [x] Top pitchers
    - [x] Top playoff batters
    - [x] Top playoff pitchers
    - [x] Current season players
    - [x] Current season teams
    - [x] Current season schedule
    - [x] Current season playoff schedule

Unsupported exports:
- Player Careers
    - Career regular season batting
    - Career regular season pitching
    - Career playoff batting
    - Career playoff pitching
- Players By Season
    - All regular season batting
    - All regular season pitching
    - Playoff batting
    - Playoff pitching
- Current season
    - Rookie batters
    - Rookie pitchers

Need to fully test with Elimination, as for that mode, it is possible that playoffs are the only thing that exist (no regular season since tournament format)

Closes #48 