### PR TITLE
Bump version to 1.7.1

### DIFF
--- a/SMB3Explorer/SMB3Explorer.csproj
+++ b/SMB3Explorer/SMB3Explorer.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <IsPackable>false</IsPackable>
-        <Version>1.6.2</Version>
+        <Version>1.7.1</Version>
         <Title>SMB Explorer</Title>
         <Authors>Trey Brittain &lt;treybrittain@gmail.com&gt;</Authors>
         <PackageProjectUrl>https://github.com/tbrittain/SMB3Explorer</PackageProjectUrl>


### PR DESCRIPTION
I accidentally forgot to bump assembly version for 1.7.0, which would annoyingly announce every time you open the app that an update is available, even if you are in fact on the download from 1.7.0. This should resolve that issue